### PR TITLE
release: Version bump to 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2024-11-06
+
 ### Added
 - Professional-grade documentation overhaul with comprehensive README.md
 - Detailed contributing guidelines in CONTRIBUTING.md
 - Formal changelog protocol following Keep a Changelog format
+- Documentation index in docs/README.md with navigation
+- Universal Why→What→How documentation structure standards
 
 ### Changed
 - Enhanced README.md with modern badges, better structure, and comprehensive examples
-- Improved project metadata and documentation standards
+- Improved project metadata and documentation standards in pyproject.toml
+- Updated architecture documentation to follow established standards
+
+### Removed
+- Unused Jinja2 dependency (project uses visitor pattern, not templates)
+- Feature status promises to avoid implementation commitments
 
 ## [0.8.3] - 2024-11-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyopenapi-gen"
-version = "0.8.3"
+version = "0.8.4"
 description = "Modern, async-first Python client generator for OpenAPI specifications with advanced cycle detection and unified type resolution"
 authors = [{ name = "Mindhive Oy", email = "contact@mindhive.fi" }]
 maintainers = [{ name = "Ville Venäläinen | Mindhive Oy", email = "ville@mindhive.fi" }]


### PR DESCRIPTION
Version bump for documentation overhaul release

- Update pyproject.toml version from 0.8.3 → 0.8.4
- Update CHANGELOG.md with 0.8.4 release notes
- Prepare for production release to main