### PR TITLE
fix: Enable PR checks for staging and main branches

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: Pull Request Checks
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [develop, staging, main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Fixes the CI workflow configuration to enable required status checks for PRs targeting staging and main branches, not just develop.

## Problem
PR #16 (develop → staging) is blocked because the PR checks workflow only runs on PRs to develop branch, but staging branch protection requires these checks.

## Solution
Updated  to trigger on PRs to all protected branches: develop, staging, and main.

## Required Checks
- test
- security-scan  
- quality-checks (3.12)

This change will allow PR #16 to get the required CI checks and be merged to continue the release flow.

🤖 Generated with [Claude Code](https://claude.ai/code)