### PR TITLE
fix: Move TestPyPI publish from main to staging branch

### DIFF
--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -2,7 +2,7 @@ name: Publish to TestPyPI (pre-release)
 
 on:
   push:
-    branches: [main]
+    branches: [staging]
 
 jobs:
   build-and-testpypi:


### PR DESCRIPTION
## Problem

The TestPyPI workflow was incorrectly configured to trigger on pushes to  branch, causing double publishing:
- Push to main → TestPyPI publish 
- Tag creation → Production PyPI publish

This violates proper release flow where main should be production-only.

## Solution

Updated TestPyPI workflow to trigger on  branch instead.

## Correct Release Pipeline
- **develop → staging**: Triggers TestPyPI (pre-release testing)
- **staging → main**: Just merges (no auto-publish) 
- **Tag on main**: Triggers Production PyPI (official release)

## Impact
- Prevents double publishing
- Follows proper staging → production flow
- TestPyPI becomes true pre-release testing environment

This fix is needed for the v0.8.5 production release to work correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)