### PR TITLE
fix: Enable CI workflow for staging branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, staging]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, staging]
 
 jobs:
   test:


### PR DESCRIPTION
## Problem

PR #20 (production release) is blocked because staging branch protection rules require the \ status check, but the CI workflow was only configured to run on \ and \ branches.

## Root Cause
- Staging branch protection: requires \, \, \  
- CI workflow: only runs on PRs to \, \ (missing \)
- PR checks workflow: runs on PRs to \, \, \

## Solution
Updated CI workflow to also trigger on PRs targeting \ branch.

## Impact
- Fixes immediate blocking issue with PR #20 (v0.8.5 production release)
- Ensures proper CI coverage for all protected branches
- Maintains consistent status check requirements

This is a critical fix needed for the production release pipeline.

🤖 Generated with [Claude Code](https://claude.ai/code)