### PR TITLE
🔧 Hotfix: Fix Poetry PATH for semantic release pipeline

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -77,6 +77,14 @@ jobs:
           echo "No release-worthy changes found since $LAST_TAG"
         fi
 
+    - name: Add Poetry to PATH
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Verify Poetry is available
+      run: |
+        which poetry
+        poetry --version
+
     - name: Python Semantic Release
       id: semantic_release
       if: steps.check_changes.outputs.release_worthy > 0 || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## 🚨 **Critical Hotfix: Semantic Release Pipeline Failure**

### 🔍 **Issue**
The semantic release pipeline is failing with:
```
bash: line 1: poetry: command not found
Command 'poetry build' returned non-zero exit status 127
```

### 🛠️ **Root Cause**
- Poetry is installed via `snok/install-poetry@v1` action
- But Poetry is not available in PATH when `python-semantic-release` action runs
- The `build_command = "poetry build"` fails because Poetry cannot be found

### ✅ **Solution**
- **Add Poetry to PATH** explicitly before semantic release step
- **Add verification step** to confirm Poetry availability  
- **Fixes build command** so automated releases can proceed

### 🔧 **Changes Made**
```yaml
# .github/workflows/semantic-release.yml
- name: Add Poetry to PATH
  run: echo "$HOME/.local/bin" >> $GITHUB_PATH

- name: Verify Poetry is available
  run: |
    which poetry
    poetry --version

- name: Python Semantic Release
  # Now poetry build will work
```

### 🎯 **Impact**
- ✅ **Unblocks automated releases** - semantic release can now build packages
- ✅ **Fixes VERSION 0.9.0 release** - the pipeline calculated v0.9.0 but failed to publish
- ✅ **Enables future automation** - all conventional commits will now trigger releases

### 🚀 **Expected Outcome**
After merge:
1. Semantic release pipeline will retry automatically
2. Version 0.9.0 should be published to PyPI  
3. Future conventional commits will trigger automated releases

### ⚡ **Urgency: Critical**
This is blocking all automated releases. The semantic release system calculated that version 0.9.0 should be released based on conventional commits, but the build step failed.

**Priority**: Immediate merge and deployment needed to restore release automation.