### PR TITLE
🔧 Critical Hotfix: Fix poetry.lock sync issue

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -157,6 +157,30 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "build"
+version = "1.2.2.post1"
+description = "A simple, correct Python build frontend"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5"},
+    {file = "build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "os_name == \"nt\""}
+packaging = ">=19.1"
+pyproject_hooks = "*"
+
+[package.extras]
+docs = ["furo (>=2023.08.17)", "sphinx (>=7.0,<8.0)", "sphinx-argparse-cli (>=1.5)", "sphinx-autodoc-typehints (>=1.10)", "sphinx-issues (>=3.0.0)"]
+test = ["build[uv,virtualenv]", "filelock (>=3)", "pytest (>=6.2.4)", "pytest-cov (>=2.12)", "pytest-mock (>=2)", "pytest-rerunfailures (>=9.1)", "pytest-xdist (>=1.34)", "setuptools (>=42.0.0)", "setuptools (>=56.0.0)", "setuptools (>=56.0.0)", "setuptools (>=67.8.0)", "wheel (>=0.36.0)"]
+typing = ["build[uv]", "importlib-metadata (>=5.1)", "mypy (>=1.9.0,<1.10.0)", "tomli", "typing-extensions (>=3.7.4.3)"]
+uv = ["uv (>=0.1.18)"]
+virtualenv = ["virtualenv (>=20.0.35)"]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1545,6 +1569,18 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+description = "Wrappers to call pyproject.toml-based build backend hooks."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913"},
+    {file = "pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8"},
+]
+
+[[package]]
 name = "pytest"
 version = "8.4.0"
 description = "pytest: simple powerful testing with Python"
@@ -2608,4 +2644,4 @@ dev = ["bandit", "black", "dataclass-wizard", "httpx", "mypy", "pytest", "pytest
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0.0"
-content-hash = "9c7086029f6d661abb30189c74da6889a109e9c0b068d563173b0b387f8c034a"
+content-hash = "4c7a5d35b7eb069af032f9112d2c717b881237a22bb3da0617152f1324ed0cd0"


### PR DESCRIPTION
## 🚨 **Critical Fix: Poetry Lock Sync Issue**

### 🔍 **Issue**
Semantic release workflow failing with:
```
pyproject.toml changed significantly since poetry.lock was last generated. 
Run poetry lock to fix the lock file.
Error: Process completed with exit code 1.
```

### 🛠️ **Root Cause**
- `pyproject.toml` has `build = "^1.2.0"` dependency ✅
- `poetry.lock` was missing the build module entry ❌
- This caused CI dependency installation to fail before reaching semantic release

### ✅ **Solution**
- **Regenerated `poetry.lock`** with `poetry lock`
- **Added build module**: Now includes `build = "1.2.2.post1"` in lock file
- **Verified dependency**: Build module properly locked and available

### 🎯 **Impact**
- ✅ **Fixes CI dependency installation** - poetry install will now work
- ✅ **Unblocks semantic release** - workflow can proceed past setup
- ✅ **Enables `python -m build`** - build command will be available

### 📋 **Changes Made**
```diff
+ [[package]]
+ name = "build"
+ version = "1.2.2.post1"
+ description = "A simple, correct Python build frontend"
```

### 🚀 **Expected Outcome**
After merge:
1. ✅ **Dependencies install correctly** in CI
2. ✅ **Semantic release workflow succeeds**
3. ✅ **Version 0.9.0 published** to PyPI
4. ✅ **Future automation works** seamlessly

### ⚡ **Urgency: Critical**
This blocks all automated releases. The semantic release system is ready but cannot start due to dependency sync issue.

**Priority**: Immediate merge needed to complete semantic release deployment.