### PR TITLE
fix(release): correct semantic-release configuration and sync version to 0.14.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,8 +154,8 @@ bump_message = "bump: version $current_version → $new_version"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version", "pyproject.toml:tool.commitizen.version"]
-version_pattern = [
-    "src/pyopenapi_gen/__init__.py:__version__: str = \"{version}\""
+version_variables = [
+    "src/pyopenapi_gen/__init__.py:__version__"
 ]
 branch = "main"
 upload_to_pypi = false

--- a/src/pyopenapi_gen/__init__.py
+++ b/src/pyopenapi_gen/__init__.py
@@ -43,7 +43,7 @@ __all__ = [
 ]
 
 # Semantic version of the generator core – automatically managed by semantic-release.
-__version__: str = "0.10.2"
+__version__: str = "0.14.3"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixed semantic-release automation to properly update __init__.py version automatically during releases.

## Problem
- Semantic-release v9 was using deprecated `version_pattern` syntax
- This caused __init__.py to NOT be automatically updated during releases
- CI validation failed: __init__.py (0.10.2) ≠ pyproject.toml (0.14.3)
- Manual intervention was required for every release (defeats automation purpose)

## Root Cause
The configuration used `version_pattern` which is:
- Deprecated in semantic-release v7
- Removed in semantic-release v8+
- Not recognized by semantic-release v9 (currently installed: 9.21.1)

## Solution
**Configuration Fix:**
- Updated `pyproject.toml` to use `version_variables` (v9+ syntax)
- This is the correct way to specify version locations in v9

**Version Sync:**
- Synced `__init__.py` version from 0.10.2 → 0.14.3 to match pyproject.toml
- Ensures all version files are synchronized

## Changes
- **pyproject.toml**: Changed `version_pattern` → `version_variables`
- **src/pyopenapi_gen/__init__.py**: Updated `__version__` from 0.10.2 → 0.14.3

## Impact
✅ Future releases will automatically sync all version files  
✅ No more manual version updates required  
✅ CI validation will pass  
✅ True automation as originally intended

## Testing
- Version validation script now passes:
  ```
  ✅ All versions are synchronised:
    ✅ pyproject.toml (project.version): 0.14.3
    ✅ pyproject.toml (tool.commitizen.version): 0.14.3
    ✅ src/pyopenapi_gen/__init__.py (__version__): 0.14.3
  ```

## References
- Semantic-release v9 documentation: version_variables syntax
- Previous failed CI run showing version mismatch