### PR TITLE
chore: sync version 2.0.1 from main to develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyopenapi-gen"
-version = "2.0.0"
+version = "2.0.1"
 description = "Modern, async-first Python client generator for OpenAPI specifications with advanced cycle detection and unified type resolution"
 authors = [{ name = "Mindhive Oy", email = "contact@mindhive.fi" }]
 maintainers = [{ name = "Ville Venäläinen | Mindhive Oy", email = "ville@mindhive.fi" }]
@@ -141,7 +141,7 @@ pyopenapi-gen = "pyopenapi_gen.cli:app"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.0.0"
+version = "2.0.1"
 version_files = [
     "pyproject.toml:version",
     "src/pyopenapi_gen/__init__.py:__version__"

--- a/src/pyopenapi_gen/__init__.py
+++ b/src/pyopenapi_gen/__init__.py
@@ -50,7 +50,7 @@ __all__ = [
 ]
 
 # Semantic version of the generator core – automatically managed by semantic-release.
-__version__: str = "2.0.0"
+__version__: str = "2.0.1"
 
 # ---------------------------------------------------------------------------
 # Lazy-loading and autocompletion support (This part remains)


### PR DESCRIPTION
## Summary
Syncs the latest release version (2.0.1) from main back to develop to ensure version numbers and changelogs are aligned.

## Changes
- ✅ Version bumped to 2.0.1 in pyproject.toml
- ✅ Version bumped to 2.0.1 in src/pyopenapi_gen/__init__.py
- ✅ CHANGELOG updates from main

## Purpose
This sync ensures develop has the correct version number before creating the next release PR to main. This prevents version conflicts and ensures semantic-release can properly calculate the next version.

## Related
Preparation for merging develop to main with latest dependency updates and Poetry lock automation.