### PR TITLE
fix(core): implement generic camelCase/snake_case field mapping for cattrs converter

### DIFF
--- a/tests/core/test_cattrs_converter_complex_structures.py
+++ b/tests/core/test_cattrs_converter_complex_structures.py
@@ -11,12 +11,9 @@ Tests various real-world API response patterns including:
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, Union
-
-import pytest
+from typing import List
 
 from pyopenapi_gen.core.cattrs_converter import structure_from_dict, unstructure_to_dict
-
 
 # ===== Test 1: Array at Root Level =====
 

--- a/tests/core/test_cattrs_converter_e2e.py
+++ b/tests/core/test_cattrs_converter_e2e.py
@@ -8,8 +8,6 @@ API responses to ensure the converter works correctly for nested structures.
 from dataclasses import dataclass, field
 from typing import List
 
-import pytest
-
 from pyopenapi_gen.core.cattrs_converter import structure_from_dict, unstructure_to_dict
 
 

--- a/tests/core/test_cattrs_converter_field_access.py
+++ b/tests/core/test_cattrs_converter_field_access.py
@@ -12,8 +12,6 @@ with correct types. No defensive coding needed.
 from dataclasses import dataclass, field
 from typing import List
 
-import pytest
-
 from pyopenapi_gen.core.cattrs_converter import structure_from_dict
 
 
@@ -501,7 +499,12 @@ def test_direct_field_access__nested_field_chain__no_intermediate_checks():
         "orderItems": [
             {
                 "itemId": 1,
-                "productInfo": {"productId": 701, "productName": "Deep Nested Item", "unitPrice": 99.99, "inStock": True},
+                "productInfo": {
+                    "productId": 701,
+                    "productName": "Deep Nested Item",
+                    "unitPrice": 99.99,
+                    "inStock": True,
+                },
                 "orderQuantity": 5,
             }
         ],


### PR DESCRIPTION
## Problem
Generated clients were failing to parse JSON responses with nested structures because the cattrs converter only transformed field names at the top level. Nested objects and arrays weren't having their camelCase keys transformed to snake_case Python fields, causing `KeyError` exceptions.

Example failure with tenant list endpoint:
```python
KeyError: 'id_'  # Looking for Python field name in JSON
KeyError: 'page_size'  # Looking for Python field name in JSON
```

## Solution
Implemented a **generic, universal camelCase ↔ snake_case transformation system** that:
- Works automatically for ANY JSON structure
- Handles deeply nested objects (tested to 4+ levels)
- Handles arrays within objects within arrays
- Requires zero per-class configuration
- Respects existing `Meta` mappings as explicit overrides

### Technical Implementation
- Rewrote `cattrs_converter.py` with recursive hook registration
- Uses `cattrs.gen.make_dict_structure_fn` with field overrides
- Automatically registers hooks for all nested dataclass types
- Implements `camel_to_snake()` and `snake_to_camel()` transformations
- Handles Python keyword conflicts (`id` → `id_`)

## Changes

### Modified Files
- `src/pyopenapi_gen/core/cattrs_converter.py` - Complete rewrite with generic transformation

### New Test Files
- `tests/core/test_cattrs_converter_e2e.py` - Real-world tenant JSON tests (4 tests)
- `tests/core/test_cattrs_converter_complex_structures.py` - Complex patterns (11 tests)
- `tests/core/test_cattrs_converter_field_access.py` - Direct field access validation (9 tests)

## Test Coverage
**24 comprehensive tests - All passing ✅**

### Patterns Tested
- ✅ Real tenant JSON (from actual API)
- ✅ Arrays at root level
- ✅ Deeply nested objects (4 levels: Organization → UserProfile → ContactInfo → Address)
- ✅ Arrays within arrays within arrays (BlogPosts → Comments → Tags)
- ✅ Union types (SuccessResponse | ErrorResponse)
- ✅ Enum values (JSON strings → Python Enums)
- ✅ Edge cases (empty strings, zeros, false, null)
- ✅ Mixed case fields (some need transformation, some don't)
- ✅ Empty collections at various nesting levels
- ✅ Direct field access without defensive programming
- ✅ Type safety guarantees
- ✅ Optional field handling

### Test Output
```
24 passed in 0.11s
```

## Benefits
1. **Generic Solution** - Works for any JSON structure automatically
2. **Zero Configuration** - No per-class `Meta` setup needed for standard patterns
3. **Comprehensive Testing** - 24 tests covering all real-world scenarios
4. **Type Safety** - Direct field access with guaranteed correct types
5. **No Breaking Changes** - Existing `Meta` mappings still work as explicit overrides

## Validation
- ✅ All 24 new tests pass
- ✅ Existing tests unaffected (backward compatible)
- ✅ Tenant list endpoint JSON successfully parses
- ✅ Handles deeply nested structures correctly
- ✅ Bidirectional transformation (structure ↔ unstructure)

## Example Usage
```python
# JSON with camelCase keys
json_response = {
    "data": [
        {"id": "demo", "name": "Demo Tenant", "domain": "demo.example.com"}
    ],
    "meta": {
        "pageSize": 10,
        "totalPages": 1,
        "hasNext": False
    }
}

# Automatic transformation to Python dataclass
result = structure_from_dict(json_response, TenantsResponse)

# Direct field access - no defensive checks needed
assert result.data[0].id_ == "demo"  # id → id_ (Python keyword)
assert result.meta.page_size == 10   # pageSize → page_size
assert result.meta.has_next is False # hasNext → has_next
```