### PR TITLE
chore(merge): sync version 2.0.2 from main to develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyopenapi-gen"
-version = "2.0.1"
+version = "2.0.2"
 description = "Modern, async-first Python client generator for OpenAPI specifications with advanced cycle detection and unified type resolution"
 authors = [{ name = "Mindhive Oy", email = "contact@mindhive.fi" }]
 maintainers = [{ name = "Ville Venäläinen | Mindhive Oy", email = "ville@mindhive.fi" }]
@@ -141,7 +141,7 @@ pyopenapi-gen = "pyopenapi_gen.cli:app"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.0.1"
+version = "2.0.2"
 version_files = [
     "pyproject.toml:version",
     "src/pyopenapi_gen/__init__.py:__version__"

--- a/src/pyopenapi_gen/__init__.py
+++ b/src/pyopenapi_gen/__init__.py
@@ -50,7 +50,7 @@ __all__ = [
 ]
 
 # Semantic version of the generator core – automatically managed by semantic-release.
-__version__: str = "2.0.1"
+__version__: str = "2.0.2"
 
 # ---------------------------------------------------------------------------
 # Lazy-loading and autocompletion support (This part remains)


### PR DESCRIPTION
## Summary

Resolves merge conflicts between main and develop by syncing version 2.0.2 from main.

## Changes

- Updated `pyproject.toml` project.version: 2.0.1 → 2.0.2
- Updated `pyproject.toml` tool.commitizen.version: 2.0.1 → 2.0.2  
- Updated `src/pyopenapi_gen/__init__.py` __version__: 2.0.1 → 2.0.2
- Regenerated `poetry.lock` after merge

## Quality Gates

✅ All formatting checks pass (Black)
✅ All linting checks pass (Ruff)
✅ All type checks pass (mypy strict mode)
✅ All security checks pass (Bandit)
✅ Version synchronisation validated

## Context

This merge brings the following changes from main into develop:
- Response unwrapping fix (#136)
- Dependabot Poetry lock fix workflow
- Claude auto-approve workflow improvements

After this PR is merged, we can proceed with creating the PR from develop to main for the cattrs field mapping fix.