### PR TITLE
perf(ci): remove redundant tests and quality checks from release pipeline

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -48,23 +48,6 @@ jobs:
       run: |
         poetry install --with dev
 
-    - name: Validate version synchronisation
-      run: |
-        echo "🔍 Checking that all version files are synchronised..."
-        poetry run python scripts/validate_version_sync.py
-        echo "✅ All version files are in sync"
-
-    - name: Run comprehensive quality checks
-      run: |
-        poetry run black --check src/ tests/
-        poetry run ruff check src/ tests/
-        poetry run mypy src/ --strict --no-warn-no-return
-        poetry run bandit -r src/ -f txt -c .bandit
-
-    - name: Run full test suite
-      run: |
-        poetry run pytest -n 2 --timeout=120 --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=85
-
     - name: Check for release-worthy changes
       id: check_changes
       run: |


### PR DESCRIPTION
## Summary

Removed redundant quality checks and tests from the semantic-release workflow that already run in PR checks before merge to main.

## Changes

Removed from :
- Version synchronisation validation
- Quality checks (Black, Ruff, mypy, Bandit)  
- Full test suite (pytest with coverage)

## Why

These checks run in the PR pipeline and are required before merge. Running them again during release wastes CI resources and time (~3 minutes saved per release).

## Quality Assurance

No compromise - all checks still enforced at PR level. Release pipeline now focuses on:
- Bumping version
- Building packages
- Publishing to PyPI
- Creating GitHub release
- Syncing to branches