### PR TITLE
chore(sync): sync develop with main v2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyopenapi-gen"
-version = "2.0.3"
+version = "2.1.0"
 description = "Modern, async-first Python client generator for OpenAPI specifications with advanced cycle detection and unified type resolution"
 authors = [{ name = "Mindhive Oy", email = "contact@mindhive.fi" }]
 maintainers = [{ name = "Ville Venäläinen | Mindhive Oy", email = "ville@mindhive.fi" }]
@@ -141,7 +141,7 @@ pyopenapi-gen = "pyopenapi_gen.cli:app"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.0.3"
+version = "2.1.0"
 version_files = [
     "pyproject.toml:version",
     "src/pyopenapi_gen/__init__.py:__version__"

--- a/src/pyopenapi_gen/__init__.py
+++ b/src/pyopenapi_gen/__init__.py
@@ -50,7 +50,7 @@ __all__ = [
 ]
 
 # Semantic version of the generator core – automatically managed by semantic-release.
-__version__: str = "2.0.3"
+__version__: str = "2.1.0"
 
 # ---------------------------------------------------------------------------
 # Lazy-loading and autocompletion support (This part remains)


### PR DESCRIPTION
## Summary
Synchronise develop branch with main after v2.1.0 release to resolve merge conflicts.

## Changes
- Merge main (v2.1.0) into develop
- Resolve version conflicts in favour of main (v2.1.0)
- Updated `pyproject.toml` version: 2.0.3 → 2.1.0
- Updated `src/pyopenapi_gen/__init__.py` __version__: 2.0.3 → 2.1.0

## Why
The PR #149 (develop → main) has merge conflicts because:
- Main is at v2.1.0 (released)
- Develop is at v2.0.3 (older)

This PR syncs develop with the latest main release before creating a new release PR.

## Test Results
- Version synchronisation validated
- All files merged successfully