### PR TITLE
chore(sync): merge main v2.3.0 release into develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyopenapi-gen"
-version = "2.2.0"
+version = "2.3.0"
 description = "Modern, async-first Python client generator for OpenAPI specifications with advanced cycle detection and unified type resolution"
 authors = [{ name = "Mindhive Oy", email = "contact@mindhive.fi" }]
 maintainers = [{ name = "Ville Venäläinen | Mindhive Oy", email = "ville@mindhive.fi" }]
@@ -141,7 +141,7 @@ pyopenapi-gen = "pyopenapi_gen.cli:app"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "2.2.0"
+version = "2.3.0"
 version_files = [
     "pyproject.toml:version",
     "src/pyopenapi_gen/__init__.py:__version__"

--- a/src/pyopenapi_gen/__init__.py
+++ b/src/pyopenapi_gen/__init__.py
@@ -50,7 +50,7 @@ __all__ = [
 ]
 
 # Semantic version of the generator core – automatically managed by semantic-release.
-__version__: str = "2.2.0"
+__version__: str = "2.3.0"
 
 # ---------------------------------------------------------------------------
 # Lazy-loading and autocompletion support (This part remains)


### PR DESCRIPTION
## Summary

Sync version 2.3.0 from main branch back to develop after semantic-release.

## Changes

- Updated version in `pyproject.toml`: 2.2.0 → 2.3.0
- Updated version in `src/pyopenapi_gen/__init__.py`: 2.2.0 → 2.3.0

## Resolution

Resolved version conflicts by accepting main branch versions (2.3.0) which reflect the latest release.