### PR TITLE
fix(codegen): preserve original API field names and detect collisions

### DIFF
--- a/tests/core/test_cattrs_converter_annotations.py
+++ b/tests/core/test_cattrs_converter_annotations.py
@@ -26,13 +26,16 @@ def test_structure_with_future_annotations():
     Scenario:
         When `from __future__ import annotations` is used, type hints become strings.
         The converter must resolve these strings to actual types to register hooks recursively.
+        For user-defined dataclasses without Meta class, Python field names are expected
+        in the JSON (no automatic camelCase conversion).
 
     Expected Outcome:
         Nested dataclasses are correctly identified and structured.
     """
+    # User-defined dataclasses without Meta use Python field names (snake_case)
     data = {
-        "items": [{"itemId": 1, "name": "one"}, {"itemId": 2, "name": "two"}],
-        "singleItem": {"itemId": 3, "name": "three"},
+        "items": [{"item_id": 1, "name": "one"}, {"item_id": 2, "name": "two"}],
+        "single_item": {"item_id": 3, "name": "three"},
     }
 
     result = structure_from_dict(data, RootContainer)

--- a/tests/integration/test_field_name_mapping_comprehensive.py
+++ b/tests/integration/test_field_name_mapping_comprehensive.py
@@ -1,0 +1,308 @@
+"""Comprehensive integration tests for field name mapping.
+
+Tests that the generator correctly handles field name mapping for:
+- snake_case API fields (preserve original names)
+- camelCase API fields (roundtrip works correctly)
+- Field collisions (unique names generated)
+- Mixed casing in same schema
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from pyopenapi_gen import generate_client
+
+
+def _create_test_spec_snake_case() -> dict:
+    """Create an OpenAPI spec with snake_case field names."""
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "Snake Case API", "version": "1.0.0"},
+        "paths": {},
+        "components": {
+            "schemas": {
+                "UserProfile": {
+                    "type": "object",
+                    "required": ["user_id", "created_at"],
+                    "properties": {
+                        "user_id": {"type": "string", "description": "The user identifier"},
+                        "created_at": {"type": "string", "format": "date-time"},
+                        "display_name": {"type": "string"},
+                        "email_address": {"type": "string"},
+                    },
+                }
+            }
+        },
+    }
+
+
+def _create_test_spec_field_collision() -> dict:
+    """Create an OpenAPI spec with field name collisions."""
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "Collision API", "version": "1.0.0"},
+        "paths": {},
+        "components": {
+            "schemas": {
+                "CollisionModel": {
+                    "type": "object",
+                    "required": ["userId", "user_id", "address"],
+                    "properties": {
+                        "userId": {"type": "string", "description": "User ID in camelCase"},
+                        "user_id": {"type": "string", "description": "User ID in snake_case"},
+                        "address": {"type": "string"},
+                    },
+                }
+            }
+        },
+    }
+
+
+def _create_test_spec_mixed_casing() -> dict:
+    """Create an OpenAPI spec with mixed field casing."""
+    return {
+        "openapi": "3.0.0",
+        "info": {"title": "Mixed Casing API", "version": "1.0.0"},
+        "paths": {},
+        "components": {
+            "schemas": {
+                "MixedModel": {
+                    "type": "object",
+                    "required": ["firstName", "last_name", "emailAddress"],
+                    "properties": {
+                        "firstName": {"type": "string"},
+                        "last_name": {"type": "string"},
+                        "emailAddress": {"type": "string"},
+                    },
+                }
+            }
+        },
+    }
+
+
+def test_field_mapping__snake_case_api__roundtrip_preserves_original_names() -> None:
+    """Test that snake_case API fields are preserved through roundtrip.
+
+    Scenario:
+        - OpenAPI spec uses snake_case field names (user_id, created_at)
+        - Generate client and deserialise API response
+        - Serialise back and verify original snake_case names are used
+
+    Expected Outcome:
+        - Python dataclass uses snake_case attributes (same as API)
+        - Serialisation produces snake_case keys (original API format)
+    """
+    import json
+
+    spec = _create_test_spec_snake_case()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_root = Path(tmpdir)
+        spec_path = project_root / "spec.json"
+        spec_path.write_text(json.dumps(spec))
+
+        generate_client(
+            spec_path=str(spec_path),
+            project_root=str(project_root),
+            output_package="snakeapi",
+            force=True,
+            no_postprocess=True,
+        )
+
+        import sys
+
+        sys.path.insert(0, str(project_root))
+
+        from snakeapi.core.cattrs_converter import structure_from_dict
+        from snakeapi.core.utils import DataclassSerializer
+        from snakeapi.models.user_profile import UserProfile
+
+        # Deserialise from API response (snake_case keys)
+        api_response = {
+            "user_id": "user-123",
+            "created_at": "2024-01-15T10:30:00Z",
+            "display_name": "John Doe",
+            "email_address": "john@example.com",
+        }
+
+        user = structure_from_dict(api_response, UserProfile)
+
+        # Verify Python attributes
+        assert user.user_id == "user-123"
+        # created_at is converted to datetime by cattrs
+        from datetime import datetime, timezone
+
+        assert user.created_at == datetime(2024, 1, 15, 10, 30, tzinfo=timezone.utc)
+        assert user.display_name == "John Doe"
+        assert user.email_address == "john@example.com"
+
+        # Serialise back
+        result = DataclassSerializer.serialize(user)
+
+        # Verify original snake_case keys are used (NOT camelCase!)
+        assert "user_id" in result, "Should use snake_case 'user_id' (original API name)"
+        assert "created_at" in result, "Should use snake_case 'created_at' (original API name)"
+        assert "display_name" in result, "Should use snake_case 'display_name' (original API name)"
+        assert "email_address" in result, "Should use snake_case 'email_address' (original API name)"
+
+        # Verify NO camelCase keys
+        assert "userId" not in result, "Should NOT convert to camelCase"
+        assert "createdAt" not in result, "Should NOT convert to camelCase"
+        assert "displayName" not in result, "Should NOT convert to camelCase"
+        assert "emailAddress" not in result, "Should NOT convert to camelCase"
+
+        # Verify values
+        assert result["user_id"] == "user-123"
+        # datetime is serialised to ISO string
+        assert result["created_at"] == "2024-01-15T10:30:00+00:00"
+
+        sys.path.remove(str(project_root))
+
+
+def test_field_mapping__field_collision__generates_unique_fields() -> None:
+    """Test that field collisions are handled with unique field names.
+
+    Scenario:
+        - OpenAPI spec has 'userId' (camelCase) and 'user_id' (snake_case)
+        - Both sanitise to 'user_id' in Python
+        - Generator should create unique field names
+
+    Expected Outcome:
+        - First field: 'user_id' (maps from 'userId')
+        - Second field: 'user_id_2' (maps from 'user_id')
+        - Both fields serialise back to their original API names
+    """
+    import json
+
+    spec = _create_test_spec_field_collision()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_root = Path(tmpdir)
+        spec_path = project_root / "spec.json"
+        spec_path.write_text(json.dumps(spec))
+
+        generate_client(
+            spec_path=str(spec_path),
+            project_root=str(project_root),
+            output_package="collisionapi",
+            force=True,
+            no_postprocess=True,
+        )
+
+        import sys
+
+        sys.path.insert(0, str(project_root))
+
+        # Read generated model to verify field names
+        model_path = project_root / "collisionapi" / "models" / "collision_model.py"
+        model_code = model_path.read_text()
+
+        # Verify unique field names were generated
+        assert "user_id:" in model_code, "First collision field 'user_id' should exist"
+        assert "user_id_2:" in model_code, "Second collision field 'user_id_2' should exist"
+        assert "address:" in model_code, "Non-colliding field 'address' should exist"
+
+        # Verify Meta class has correct mappings
+        assert "key_transform_with_load" in model_code
+        assert "key_transform_with_dump" in model_code
+
+        from collisionapi.core.cattrs_converter import structure_from_dict
+        from collisionapi.core.utils import DataclassSerializer
+        from collisionapi.models.collision_model import CollisionModel
+
+        # Deserialise from API response
+        api_response = {
+            "userId": "camel-user-id",
+            "user_id": "snake-user-id",
+            "address": "123 Main St",
+        }
+
+        model = structure_from_dict(api_response, CollisionModel)
+
+        # Verify both values are accessible
+        assert model.user_id == "camel-user-id", "user_id should have value from 'userId'"
+        assert model.user_id_2 == "snake-user-id", "user_id_2 should have value from 'user_id'"
+        assert model.address == "123 Main St"
+
+        # Serialise back
+        result = DataclassSerializer.serialize(model)
+
+        # Verify both original API names are used
+        assert "userId" in result, "Should serialise to original 'userId'"
+        assert "user_id" in result, "Should serialise to original 'user_id'"
+        assert result["userId"] == "camel-user-id"
+        assert result["user_id"] == "snake-user-id"
+
+        sys.path.remove(str(project_root))
+
+
+def test_field_mapping__mixed_casing__all_fields_mapped_correctly() -> None:
+    """Test that mixed casing fields all map correctly.
+
+    Scenario:
+        - OpenAPI spec has: 'firstName' (camelCase), 'last_name' (snake_case), 'emailAddress' (camelCase)
+        - All should be mapped correctly
+
+    Expected Outcome:
+        - All fields deserialise correctly
+        - All fields serialise back to their original format
+    """
+    import json
+
+    spec = _create_test_spec_mixed_casing()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_root = Path(tmpdir)
+        spec_path = project_root / "spec.json"
+        spec_path.write_text(json.dumps(spec))
+
+        generate_client(
+            spec_path=str(spec_path),
+            project_root=str(project_root),
+            output_package="mixedapi",
+            force=True,
+            no_postprocess=True,
+        )
+
+        import sys
+
+        sys.path.insert(0, str(project_root))
+
+        from mixedapi.core.cattrs_converter import structure_from_dict
+        from mixedapi.core.utils import DataclassSerializer
+        from mixedapi.models.mixed_model import MixedModel
+
+        # Deserialise from API response (mixed casing)
+        api_response = {
+            "firstName": "John",
+            "last_name": "Doe",
+            "emailAddress": "john@example.com",
+        }
+
+        model = structure_from_dict(api_response, MixedModel)
+
+        # Verify Python attributes (all snake_case)
+        assert model.first_name == "John"
+        assert model.last_name == "Doe"
+        assert model.email_address == "john@example.com"
+
+        # Serialise back
+        result = DataclassSerializer.serialize(model)
+
+        # Verify original casing is preserved
+        assert "firstName" in result, "Should use original camelCase 'firstName'"
+        assert "last_name" in result, "Should use original snake_case 'last_name'"
+        assert "emailAddress" in result, "Should use original camelCase 'emailAddress'"
+
+        # Verify values
+        assert result["firstName"] == "John"
+        assert result["last_name"] == "Doe"
+        assert result["emailAddress"] == "john@example.com"
+
+        sys.path.remove(str(project_root))
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/visit/model/test_dataclass_generator_collisions.py
+++ b/tests/visit/model/test_dataclass_generator_collisions.py
@@ -1,0 +1,301 @@
+"""Unit tests for field name collision detection in DataclassGenerator.
+
+Tests that the DataclassGenerator correctly handles field name collisions when
+multiple API field names sanitise to the same Python field name.
+"""
+
+import pytest
+
+from pyopenapi_gen import IRSchema
+from pyopenapi_gen.context.render_context import RenderContext
+from pyopenapi_gen.core.writers.python_construct_renderer import PythonConstructRenderer
+from pyopenapi_gen.visit.model.dataclass_generator import DataclassGenerator
+
+
+@pytest.fixture
+def render_context() -> RenderContext:
+    """Create a render context for testing."""
+    return RenderContext(
+        core_package_name="testclient.core",
+        package_root_for_generated_code="/tmp/testclient",
+        overall_project_root="/tmp",
+        parsed_schemas={},
+    )
+
+
+@pytest.fixture
+def dataclass_generator() -> DataclassGenerator:
+    """Create a DataclassGenerator for testing."""
+    renderer = PythonConstructRenderer()
+    return DataclassGenerator(renderer=renderer, all_schemas={})
+
+
+def test_generate__field_collision_userId_user_id__creates_unique_fields(
+    dataclass_generator: DataclassGenerator, render_context: RenderContext
+) -> None:
+    """Test that userId and user_id fields are both generated with unique names.
+
+    Scenario:
+        - Schema has two properties: 'userId' (camelCase) and 'user_id' (snake_case)
+        - Both sanitise to 'user_id' in Python
+        - Generator should detect collision and create unique field names
+
+    Expected Outcome:
+        - First field keeps 'user_id'
+        - Second field gets 'user_id_2'
+        - Both field mappings are correct in Meta class
+    """
+    # Arrange
+    schema = IRSchema(
+        name="UserData",
+        type="object",
+        properties={
+            "userId": IRSchema(name="userId", type="string"),
+            "user_id": IRSchema(name="user_id", type="string"),
+            "address": IRSchema(name="address", type="string"),
+        },
+        required=["userId", "user_id", "address"],
+    )
+
+    # Act
+    code = dataclass_generator.generate(schema, "UserData", render_context)
+
+    # Assert - Both fields should exist with unique names
+    assert "user_id: str" in code, "First collision field 'user_id' should exist"
+    assert "user_id_2: str" in code, "Second collision field 'user_id_2' should exist"
+    assert "address: str" in code, "Non-colliding field 'address' should exist"
+
+    # Assert - Meta class should have correct mappings
+    assert "class Meta:" in code, "Meta class should be generated"
+    assert '"userId": "user_id"' in code, "userId should map to user_id"
+    assert '"user_id": "user_id_2"' in code, "user_id should map to user_id_2"
+
+
+def test_generate__field_collision_three_variants__applies_suffixes(
+    dataclass_generator: DataclassGenerator, render_context: RenderContext
+) -> None:
+    """Test that three colliding field names all get unique suffixes.
+
+    Scenario:
+        - Schema has 'userId', 'user_id', and 'User_ID' properties
+        - All sanitise to 'user_id' in Python
+        - Generator should create unique names for all three
+
+    Expected Outcome:
+        - First field: 'user_id'
+        - Second field: 'user_id_2'
+        - Third field: 'user_id_3'
+    """
+    # Arrange
+    schema = IRSchema(
+        name="UserIdentifiers",
+        type="object",
+        properties={
+            "userId": IRSchema(name="userId", type="string"),
+            "user_id": IRSchema(name="user_id", type="string"),
+            "User_ID": IRSchema(name="User_ID", type="string"),
+        },
+        required=["userId", "user_id", "User_ID"],
+    )
+
+    # Act
+    code = dataclass_generator.generate(schema, "UserIdentifiers", render_context)
+
+    # Assert - All three fields should exist with unique names
+    assert "user_id: str" in code, "First collision field 'user_id' should exist"
+    assert "user_id_2: str" in code, "Second collision field 'user_id_2' should exist"
+    assert "user_id_3: str" in code, "Third collision field 'user_id_3' should exist"
+
+
+def test_generate__no_collision__no_suffix_applied(
+    dataclass_generator: DataclassGenerator, render_context: RenderContext
+) -> None:
+    """Test that fields without collision don't get suffixes.
+
+    Scenario:
+        - Schema has 'firstName', 'lastName', 'address' properties
+        - None collide after sanitisation
+        - No suffixes should be applied
+
+    Expected Outcome:
+        - Fields: 'first_name', 'last_name', 'address'
+        - No '_2' or '_3' suffixes
+    """
+    # Arrange
+    schema = IRSchema(
+        name="Person",
+        type="object",
+        properties={
+            "firstName": IRSchema(name="firstName", type="string"),
+            "lastName": IRSchema(name="lastName", type="string"),
+            "address": IRSchema(name="address", type="string"),
+        },
+        required=["firstName", "lastName", "address"],
+    )
+
+    # Act
+    code = dataclass_generator.generate(schema, "Person", render_context)
+
+    # Assert - Fields should exist without suffixes
+    assert "first_name: str" in code
+    assert "last_name: str" in code
+    assert "address: str" in code
+
+    # Assert - No collision suffixes applied
+    assert "_2" not in code, "No collision suffixes should be present"
+    assert "_3" not in code, "No collision suffixes should be present"
+
+
+def test_generate__collision_with_required_fields__preserves_required_status(
+    dataclass_generator: DataclassGenerator, render_context: RenderContext
+) -> None:
+    """Test that field collision handling preserves required/optional status.
+
+    Scenario:
+        - 'userId' is required, 'user_id' is optional
+        - Both collide to 'user_id'
+        - Required status should be preserved for each
+
+    Expected Outcome:
+        - 'user_id' (from userId) should be required (no default)
+        - 'user_id_2' (from user_id) should be optional (has default)
+    """
+    # Arrange
+    schema = IRSchema(
+        name="UserWithOptional",
+        type="object",
+        properties={
+            "userId": IRSchema(name="userId", type="string"),
+            "user_id": IRSchema(name="user_id", type="string"),
+        },
+        required=["userId"],  # Only userId is required
+    )
+
+    # Act
+    code = dataclass_generator.generate(schema, "UserWithOptional", render_context)
+
+    # Assert - First field (from userId) should be required
+    # Required fields appear before optional fields in sorted order
+    assert "user_id: str" in code, "Required field should exist"
+
+    # Assert - Second field (from user_id) should be optional
+    assert "user_id_2: str" in code or "user_id_2: str | None" in code
+
+
+def test_field_mappings__collision__both_api_names_preserved(
+    dataclass_generator: DataclassGenerator, render_context: RenderContext
+) -> None:
+    """Test that Meta class preserves both original API names in mappings.
+
+    Scenario:
+        - 'dataSourceId' and 'data_source_id' collide
+        - Meta class should correctly map both to their Python names
+
+    Expected Outcome:
+        - key_transform_with_load: {"dataSourceId": "data_source_id", "data_source_id": "data_source_id_2"}
+        - key_transform_with_dump: {"data_source_id": "dataSourceId", "data_source_id_2": "data_source_id"}
+    """
+    # Arrange
+    schema = IRSchema(
+        name="DataSource",
+        type="object",
+        properties={
+            "dataSourceId": IRSchema(name="dataSourceId", type="string"),
+            "data_source_id": IRSchema(name="data_source_id", type="string"),
+        },
+        required=["dataSourceId", "data_source_id"],
+    )
+
+    # Act
+    code = dataclass_generator.generate(schema, "DataSource", render_context)
+
+    # Assert - Meta class should have correct bidirectional mappings
+    assert "key_transform_with_load" in code
+    assert "key_transform_with_dump" in code
+
+    # Load mappings (API → Python)
+    assert '"dataSourceId": "data_source_id"' in code
+    assert '"data_source_id": "data_source_id_2"' in code
+
+    # Dump mappings (Python → API)
+    assert '"data_source_id": "dataSourceId"' in code
+    assert '"data_source_id_2": "data_source_id"' in code
+
+
+def test_generate__snake_case_api_field__preserves_original_name(
+    dataclass_generator: DataclassGenerator, render_context: RenderContext
+) -> None:
+    """Test that snake_case API fields are mapped back to their original names.
+
+    Scenario:
+        - API spec uses snake_case: 'user_id', 'created_at'
+        - Python fields: 'user_id', 'created_at' (same)
+        - Meta class should still map to preserve original names
+
+    Expected Outcome:
+        - Meta class contains mappings even when names match
+        - Ensures serialisation uses original API names
+    """
+    # Arrange
+    schema = IRSchema(
+        name="SnakeCaseModel",
+        type="object",
+        properties={
+            "user_id": IRSchema(name="user_id", type="string"),
+            "created_at": IRSchema(name="created_at", type="string"),
+        },
+        required=["user_id", "created_at"],
+    )
+
+    # Act
+    code = dataclass_generator.generate(schema, "SnakeCaseModel", render_context)
+
+    # Assert - Meta class should exist with mappings
+    assert "class Meta:" in code, "Meta class should be generated even when names match"
+    assert "key_transform_with_load" in code
+    assert "key_transform_with_dump" in code
+
+    # Assert - Mappings should preserve original names
+    assert '"user_id": "user_id"' in code, "user_id should map to itself"
+    assert '"created_at": "created_at"' in code, "created_at should map to itself"
+
+
+def test_generate__kebab_case_api_field__maps_correctly(
+    dataclass_generator: DataclassGenerator, render_context: RenderContext
+) -> None:
+    """Test that kebab-case API fields are mapped correctly.
+
+    Scenario:
+        - API spec uses kebab-case: 'user-id', 'created-at'
+        - Python fields: 'user_id', 'created_at'
+        - Meta class should map Python names back to kebab-case
+
+    Expected Outcome:
+        - key_transform_with_dump maps 'user_id' to 'user-id'
+        - key_transform_with_load maps 'user-id' to 'user_id'
+    """
+    # Arrange
+    schema = IRSchema(
+        name="KebabCaseModel",
+        type="object",
+        properties={
+            "user-id": IRSchema(name="user-id", type="string"),
+            "created-at": IRSchema(name="created-at", type="string"),
+        },
+        required=["user-id", "created-at"],
+    )
+
+    # Act
+    code = dataclass_generator.generate(schema, "KebabCaseModel", render_context)
+
+    # Assert - Fields should be snake_case
+    assert "user_id: str" in code
+    assert "created_at: str" in code
+
+    # Assert - Meta mappings should use kebab-case for API
+    assert '"user-id": "user_id"' in code, "Load mapping should map kebab-case to snake_case"
+    assert '"user_id": "user-id"' in code, "Dump mapping should map snake_case to kebab-case"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Fix incorrect camelCase assumption when serialising API fields back to JSON
- Add field name collision detection with numeric suffix strategy
- Ensure roundtrip serialisation preserves original API field naming conventions

## Problem

The generator assumed OpenAPI specs use camelCase field names. When specs use snake_case or other conventions, serialisation would incorrectly convert to camelCase via `snake_to_camel()` fallback, breaking API compatibility.

**Example of the bug:**
- API spec field: `user_id` (snake_case)
- Python attribute: `user_id`
- Serialisation output: `userId` ❌ (should be `user_id`)

## Solution

1. **Always create field mappings** - Every field now has explicit mapping in Meta class
2. **Remove incorrect fallback** - No longer assumes camelCase when Meta mapping is absent
3. **Collision detection** - When `userId` and `user_id` both sanitise to `user_id`, applies suffix: `user_id`, `user_id_2`

## Test Plan

- [x] Unit tests for collision detection (7 test cases)
- [x] Integration tests for roundtrip serialisation (3 test cases)
- [x] All 1448 existing tests pass
- [x] 89% code coverage (above 85% requirement)
- [x] All quality gates pass