### PR TITLE
fix(discriminator): resolve enum values via schema references

### DIFF
--- a/src/pyopenapi_gen/core/parsing/transformers/discriminator_enum_collector.py
+++ b/src/pyopenapi_gen/core/parsing/transformers/discriminator_enum_collector.py
@@ -250,22 +250,43 @@ class DiscriminatorEnumCollector:
                 )
                 continue
 
-            # Check if property has enum values
-            if not hasattr(disc_property, "enum") or not disc_property.enum:
+            # Resolve enum values - either inline or via reference
+            resolved_enum_values: list[Any] | None = None
+            resolved_enum_name: str | None = None
+
+            # Check for inline enum values first
+            if hasattr(disc_property, "enum") and disc_property.enum:
+                resolved_enum_values = disc_property.enum
+                if hasattr(disc_property, "name") and disc_property.name:
+                    resolved_enum_name = disc_property.name
+            # If no inline enum, check if property references an enum schema
+            elif hasattr(disc_property, "_refers_to_schema") and disc_property._refers_to_schema:
+                referred_schema = disc_property._refers_to_schema
+                if hasattr(referred_schema, "enum") and referred_schema.enum:
+                    resolved_enum_values = referred_schema.enum
+                    if hasattr(referred_schema, "name") and referred_schema.name:
+                        resolved_enum_name = referred_schema.name
+                    logger.debug(
+                        f"DiscriminatorEnumCollector: Resolved enum values for discriminator property '{property_name}' "
+                        f"in variant '{variant_schema.name}' via _refers_to_schema to '{referred_schema.name}'."
+                    )
+
+            # If still no enum values found, skip variant
+            if not resolved_enum_values:
                 logger.debug(
                     f"DiscriminatorEnumCollector: Discriminator property '{property_name}' "
-                    f"in variant '{variant_schema.name}' has no enum values. Skipping variant."
+                    f"in variant '{variant_schema.name}' has no enum values (inline or referenced). Skipping variant."
                 )
                 continue
 
             # Collect enum values
-            for value in disc_property.enum:
+            for value in resolved_enum_values:
                 member_name = self._generate_member_name(value)
                 enum_values.append((member_name, value))
 
             # Track variant enum name for skipping
-            if hasattr(disc_property, "name") and disc_property.name:
-                variant_enum_names.add(disc_property.name)
+            if resolved_enum_name:
+                variant_enum_names.add(resolved_enum_name)
 
         if not enum_values:
             logger.debug(


### PR DESCRIPTION
## Summary

Fixes discriminator enum collector to resolve enum values through schema references (`_refers_to_schema`) when discriminator properties use `$ref` instead of inline enum values.

## Problem

When a discriminator property referenced an enum schema via `$ref`:
```yaml
WorkflowConnectorNode:
  properties:
    type:
      $ref: '#/components/schemas/ConnectorToolConfigTypeEnum'
```

The discriminator collector skipped the variant because:
- Property had `enum=None` (it's a reference)
- Property had `_refers_to_schema` pointing to the actual enum
- Collector only checked for inline enums

Result: Incomplete unified enums causing runtime deserialization failures.

## Solution

Modified `_process_discriminated_union()` to resolve enum values through both:
1. Inline enum values (existing behaviour - preserved)
2. Referenced enum schemas via `_refers_to_schema` (new fix)

## Changes

- **Modified**: `discriminator_enum_collector.py` - Added enum reference resolution logic
- **Added**: Comprehensive test for referenced enum scenario

## Testing

- ✅ New test: `test_collect_unified_enums__property_references_enum_schema__resolves_enum_values`
- ✅ All tests: 1566/1566 passed
- ✅ Coverage: 89.07% (requirement: 85%)

## Quality Gates

- ✅ Black formatting
- ✅ Ruff linting
- ✅ mypy strict type checking
- ✅ Bandit security
- ✅ Version synchronisation

## Backward Compatibility

Fully backward compatible - inline enums continue to work as before.