### PR TITLE
test: cover optional security requirements

### DIFF
--- a/tests/core/test_loader.py
+++ b/tests/core/test_loader.py
@@ -109,6 +109,50 @@ def test_load_ir_from_spec__minimal_openapi_spec__creates_ir_with_basic_componen
     assert op.responses[0].status_code == "200"
 
 
+def test_load_ir_from_spec__optional_security_requirement__keeps_operation() -> None:
+    """
+    Scenario:
+        load_ir_from_spec processes an operation where an empty security
+        requirement makes an API-key protected operation optional.
+
+    Expected Outcome:
+        The loader should keep parsing the operation and response data even
+        though security requirements are not part of the current IR model.
+    """
+    spec = {
+        "openapi": "3.1.0",
+        "info": {"title": "Optional Security", "version": "1.0.0"},
+        "paths": {
+            "/items": {
+                "get": {
+                    "operationId": "listItems",
+                    "security": [{}, {"apiKeyAuth": []}],
+                    "responses": {"204": {"description": "No content"}},
+                }
+            }
+        },
+        "components": {
+            "securitySchemes": {
+                "apiKeyAuth": {
+                    "type": "apiKey",
+                    "in": "header",
+                    "name": "X-API-Key",
+                }
+            }
+        },
+    }
+
+    ir = load_ir_from_spec(spec)
+
+    assert len(ir.operations) == 1
+    op = ir.operations[0]
+    assert op.operation_id == "listItems"
+    assert op.method == HTTPMethod.GET
+    assert op.path == "/items"
+    assert len(op.responses) == 1
+    assert op.responses[0].status_code == "204"
+
+
 def test_load_ir_from_spec__operation_with_query_parameters__parses_params_with_types() -> None:
     """
     Scenario:


### PR DESCRIPTION
Summary
- Adds loader coverage for an operation whose security requirements include an anonymous `{}` alternative and an API key option.
- Verifies the operation and response still parse while security requirements remain outside the current IR model.

Validation
- `uv run --python 3.12 --with pytest pytest tests/core/test_loader.py -k optional_security_requirement -q`
- `git diff --check`

Duplicate gate
- Checked memory, target tree, direct PR and issue lists, and search until GitHub Search returned a rate-limit response. No same-surface duplicate found.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mindhiveoy/codesmith/pyopenapi_gen/pr/343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785632009&installation_id=140942492&pr_number=343&repository=mindhiveoy%2Fpyopenapi_gen&return_to=https%3A%2F%2Fgithub.com%2Fmindhiveoy%2Fpyopenapi_gen%2Fpull%2F343&signature=59a3e0ff07dcb11ad7409404233cd05cfcd342bd42e9daa669ebd450fe6523c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->