### PR TITLE
fix: pass Ruff bulk targets via response files

### DIFF
--- a/src/pyopenapi_gen/core/postprocess_manager.py
+++ b/src/pyopenapi_gen/core/postprocess_manager.py
@@ -1,5 +1,6 @@
 import subprocess  # nosec B404 - Required for running code formatters (Black, Ruff) and mypy
 import sys
+import tempfile
 from pathlib import Path
 from typing import List, Union
 
@@ -71,7 +72,7 @@ class PostprocessManager:
         """Remove unused imports from multiple targets using Ruff (bulk operation)."""
         if not targets:
             return
-        result = subprocess.run(  # nosec B603 - Controlled subprocess with hardcoded command
+        result = self._run_ruff_with_response_file(
             [
                 sys.executable,
                 "-m",
@@ -79,11 +80,8 @@ class PostprocessManager:
                 "check",
                 "--select=F401",
                 "--fix",
-            ]
-            + [str(t) for t in targets],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+            ],
+            targets,
         )
         if result.returncode != 0 or result.stderr:
             if result.stdout:
@@ -95,7 +93,7 @@ class PostprocessManager:
         """Sort imports in multiple targets using Ruff (bulk operation)."""
         if not targets:
             return
-        result = subprocess.run(  # nosec B603 - Controlled subprocess with hardcoded command
+        result = self._run_ruff_with_response_file(
             [
                 sys.executable,
                 "-m",
@@ -103,11 +101,8 @@ class PostprocessManager:
                 "check",
                 "--select=I",
                 "--fix",
-            ]
-            + [str(t) for t in targets],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+            ],
+            targets,
         )
         if result.returncode != 0 or result.stderr:
             if result.stdout:
@@ -119,23 +114,40 @@ class PostprocessManager:
         """Format code in multiple targets using Ruff (bulk operation)."""
         if not targets:
             return
-        result = subprocess.run(  # nosec B603 - Controlled subprocess with hardcoded command
+        result = self._run_ruff_with_response_file(
             [
                 sys.executable,
                 "-m",
                 "ruff",
                 "format",
-            ]
-            + [str(t) for t in targets],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
+            ],
+            targets,
         )
         if result.returncode != 0 or result.stderr:
             if result.stdout:
                 _print_filtered_stdout(result.stdout)
             if result.stderr:
                 print(result.stderr, file=sys.stderr)
+
+    def _run_ruff_with_response_file(self, command: List[str], targets: List[Path]) -> subprocess.CompletedProcess[str]:
+        """Run Ruff with target paths loaded from a response file.
+
+        Passing generated files directly on the command line can exceed Windows'
+        command-line length limit for large OpenAPI specs.
+        """
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".rsp", delete=False, encoding="utf-8") as response_file:
+            response_path = Path(response_file.name)
+            response_file.write("\n".join(str(target.resolve()) for target in targets))
+
+        try:
+            return subprocess.run(  # nosec B603 - Controlled subprocess with hardcoded command
+                [*command, f"@{response_path}"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        finally:
+            response_path.unlink(missing_ok=True)
 
     def remove_unused_imports(self, target: Union[str, Path]) -> None:
         """Remove unused imports from the target using Ruff."""

--- a/tests/core/test_postprocess_manager.py
+++ b/tests/core/test_postprocess_manager.py
@@ -1,0 +1,75 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from pyopenapi_gen.core.postprocess_manager import PostprocessManager
+
+
+def test_remove_unused_imports_bulk__many_targets__uses_response_file(monkeypatch, tmp_path):
+    """
+    Scenario: Ruff receives many generated files during post-processing.
+    Expected Outcome: File paths are passed through a response file, avoiding Windows command-line limits.
+    """
+    captured: dict[str, object] = {}
+    targets = [tmp_path / f"generated_{index}.py" for index in range(3)]
+    for target in targets:
+        target.write_text("import os\n", encoding="utf-8")
+
+    def fake_run(command, **kwargs):
+        response_arg = command[-1]
+        response_path = Path(response_arg[1:])
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        captured["response_arg"] = response_arg
+        captured["response_path"] = response_path
+        captured["response_text"] = response_path.read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    PostprocessManager(str(tmp_path)).remove_unused_imports_bulk(targets)
+
+    assert captured["command"][:-1] == [
+        sys.executable,
+        "-m",
+        "ruff",
+        "check",
+        "--select=F401",
+        "--fix",
+    ]
+    assert str(captured["response_arg"]).startswith("@")
+    assert captured["response_text"] == "\n".join(str(target.resolve()) for target in targets)
+    assert not Path(captured["response_path"]).exists()
+    assert captured["kwargs"] == {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+    }
+
+
+def test_format_code_bulk__many_targets__uses_response_file(monkeypatch, tmp_path):
+    """
+    Scenario: Ruff format receives many generated files during post-processing.
+    Expected Outcome: Formatting uses the same response-file path transport as Ruff checks.
+    """
+    captured: dict[str, object] = {}
+    target = tmp_path / "generated.py"
+    target.write_text("x=1\n", encoding="utf-8")
+
+    def fake_run(command, **kwargs):
+        response_path = Path(command[-1][1:])
+        captured["command"] = command
+        captured["response_text"] = response_path.read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    PostprocessManager(str(tmp_path)).format_code_bulk([target])
+
+    assert captured["command"][:-1] == [
+        sys.executable,
+        "-m",
+        "ruff",
+        "format",
+    ]
+    assert captured["response_text"] == str(target.resolve())


### PR DESCRIPTION
## Summary
- pass bulk Ruff targets through a temporary response file to avoid Windows command-line length limits
- apply the response-file path transport to unused-import cleanup, import sorting, and formatting
- add focused tests for response-file invocation and cleanup

Fixes #345

## Verification
- `python -m pytest tests\core\test_postprocess_manager.py -q`
- `python -m pytest tests\test_init.py tests\core\test_import_resolution.py tests\core\test_postprocess_manager.py -q`
- `python -m ruff check src\pyopenapi_gen\core\postprocess_manager.py tests\core\test_postprocess_manager.py`
- `python -m ruff format --check src\pyopenapi_gen\core\postprocess_manager.py tests\core\test_postprocess_manager.py`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mindhiveoy/codesmith/pyopenapi_gen/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786003222&installation_id=140942492&pr_number=346&repository=mindhiveoy%2Fpyopenapi_gen&return_to=https%3A%2F%2Fgithub.com%2Fmindhiveoy%2Fpyopenapi_gen%2Fpull%2F346&signature=c91d9309f6e286f5bec602c6d00b7b63ed64c2cbc7ba1a967038b4469aa2897b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->