### PR TITLE
ci(release): back-merge release into develop/staging via PR

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -337,65 +337,60 @@ jobs:
         echo "released_version=$LATEST_TAG" >> $GITHUB_OUTPUT
         echo "Released version: $LATEST_TAG"
 
-    - name: Sync version to staging branch
+    # Back-merge the release commits (version bump + CHANGELOG) from main into the
+    # long-lived branches. develop/staging are protected, so we CANNOT push to them
+    # directly (GH006: protected branch update failed) — instead we open a PR and let
+    # it be reviewed/merged. The release commits are chore(release):, which do not
+    # trigger a new release, so the back-merge PR is safe.
+    - name: Back-merge release into develop and staging
       if: success() && steps.get_version.outputs.released_version != ''
       env:
         GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        RELEASED_VERSION: ${{ steps.get_version.outputs.released_version }}
       run: |
-        echo "🔄 Syncing main to staging branch..."
-        
-        # Fetch all branches
-        git fetch origin staging:staging || echo "Staging branch doesn't exist, skipping"
-        
-        if git show-ref --verify --quiet refs/heads/staging; then
-          # Switch to staging and merge main
-          git checkout staging
-          git merge main --no-edit || {
-            echo "⚠️ Merge conflict detected, creating PR instead"
-            git merge --abort
-            gh pr create \
-              --title "chore: sync version ${{ steps.get_version.outputs.released_version }} from main to staging" \
-              --body "Automated sync of semantic release version ${{ steps.get_version.outputs.released_version }} from main branch" \
-              --base staging \
-              --head main \
-              --label "automated,version-sync" || echo "PR may already exist"
-          } && {
-            echo "✅ Successfully merged main into staging"
-            git push origin staging || echo "Failed to push to staging"
-          }
-        else
-          echo "ℹ️ Staging branch doesn't exist, skipping sync"
-        fi
+        set -euo pipefail
+        git fetch origin main --quiet
 
-    - name: Sync version to develop branch  
-      if: success() && steps.get_version.outputs.released_version != ''
-      env:
-        GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-      run: |
-        echo "🔄 Syncing main to develop branch..."
-        
-        # Fetch all branches
-        git fetch origin develop:develop || echo "Develop branch doesn't exist, skipping"
-        
-        if git show-ref --verify --quiet refs/heads/develop; then
-          # Switch to develop and merge main
-          git checkout develop
-          git merge main --no-edit || {
-            echo "⚠️ Merge conflict detected, creating PR instead"
-            git merge --abort
-            gh pr create \
-              --title "chore: sync version ${{ steps.get_version.outputs.released_version }} from main to develop" \
-              --body "Automated sync of semantic release version ${{ steps.get_version.outputs.released_version }} from main branch" \
-              --base develop \
-              --head main \
-              --label "automated,version-sync" || echo "PR may already exist"
-          } && {
-            echo "✅ Successfully merged main into develop"
-            git push origin develop || echo "Failed to push to develop"
-          }
-        else
-          echo "ℹ️ Develop branch doesn't exist, skipping sync"
-        fi
+        open_backmerge_pr() {
+          local target="$1"
+
+          if ! git ls-remote --exit-code --heads origin "$target" >/dev/null 2>&1; then
+            echo "ℹ️ '$target' branch doesn't exist, skipping"
+            return 0
+          fi
+
+          git fetch origin "$target" --quiet
+
+          # Nothing to do if the target already contains main's HEAD.
+          if git merge-base --is-ancestor origin/main "origin/$target"; then
+            echo "✅ '$target' already contains main, nothing to back-merge"
+            return 0
+          fi
+
+          # Reuse an existing open back-merge PR instead of opening a duplicate.
+          local existing
+          existing=$(gh pr list --base "$target" --head main --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$existing" ]; then
+            echo "ℹ️ Back-merge PR into '$target' already open: #$existing"
+            return 0
+          fi
+
+          local url
+          url=$(gh pr create \
+            --base "$target" \
+            --head main \
+            --title "chore: back-merge release ${RELEASED_VERSION} into ${target}" \
+            --body "Automated back-merge of release **${RELEASED_VERSION}** from \`main\` into \`${target}\` (version bump + CHANGELOG). Contains only \`chore(release)\` commits, so it will not trigger a new release.")
+          echo "✅ Opened back-merge PR into '$target': $url"
+          # Labels are best-effort (they may not exist in the repo).
+          gh pr edit "$url" --add-label "automated" --add-label "version-sync" 2>/dev/null \
+            || echo "(labels not applied — 'automated'/'version-sync' may not exist)"
+        }
+
+        echo "🔄 Opening back-merge PR: main → develop..."
+        open_backmerge_pr develop
+        echo "🔄 Opening back-merge PR: main → staging..."
+        open_backmerge_pr staging
 
     - name: Create release summary
       if: success()
@@ -406,7 +401,7 @@ jobs:
         echo "- **GitHub Release**: [Release Notes](https://github.com/mindhiveoy/pyopenapi_gen/releases/tag/${{ steps.get_version.outputs.released_version }})" >> $GITHUB_STEP_SUMMARY
         
         if [ -n "${{ steps.get_version.outputs.released_version }}" ]; then
-          echo "- **Branch Sync**: Version synced to staging and develop branches" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch Sync**: Back-merge PR(s) opened into develop/staging (review & merge to sync the version + CHANGELOG)" >> $GITHUB_STEP_SUMMARY
         fi
 
   notify-completion:


### PR DESCRIPTION
## Problem

After a release on `main`, the version bump + `CHANGELOG` never returned to `develop`. Confirmed drift: `main` = **5.1.7**, `develop` = **5.1.6** (and the earlier #327 release commits are also still missing from develop — the gap grows every release).

Root cause: the `Sync version to develop/staging` steps merged `main` locally and then **pushed directly** to those branches. `develop` and `staging` are protected, so the push was rejected:

```
remote: error: GH006: Protected branch update failed for refs/heads/develop.
 ! [remote rejected] develop -> develop (protected branch hook declined)
Failed to push to develop
```

The failure was swallowed by `|| echo "Failed to push"`, so the job stayed green and the drift went unnoticed. The PR fallback only fired on a *merge conflict* — never on a protected-branch rejection of a clean fast-forward.

## Fix

Replace both steps with one **`Back-merge release into develop and staging`** step that opens a **PR** (`main` → `develop`, `main` → `staging`) instead of pushing. This:

- works with branch protection (no direct push);
- gives the back-merge human review before it lands;
- is safe — it carries only `chore(release)` commits, which do **not** trigger a new release;
- is idempotent — no-ops when the target already contains `main` or when a back-merge PR is already open;
- uses `set -euo pipefail` and no longer hides push failures.

## Notes / follow-ups

- **Token:** the step uses `SEMANTIC_RELEASE_TOKEN || GITHUB_TOKEN`. With the default `GITHUB_TOKEN`, the opened PR won't trigger downstream check workflows (GitHub's recursion guard); if `develop` requires status checks to merge, set `SEMANTIC_RELEASE_TOKEN` (PAT/App token) so checks run on the back-merge PR.
- **Current drift** is being resynced by a separate one-time back-merge PR (`main` → `develop`); this workflow change only touches `.github/workflows/semantic-release.yml`, so it won't conflict with it.
- **Longer term** (not in this PR): consider deriving the package version from the git tag at build time (`poetry-dynamic-versioning`) so version files can't drift at all — then the back-merge would only need to carry the CHANGELOG.

## Validation

- `semantic-release.yml` parses as valid YAML.
- The embedded back-merge script passes `bash -n`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mindhiveoy/codesmith/pyopenapi_gen/pr/350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786017514&installation_id=140942492&pr_number=350&repository=mindhiveoy%2Fpyopenapi_gen&return_to=https%3A%2F%2Fgithub.com%2Fmindhiveoy%2Fpyopenapi_gen%2Fpull%2F350&signature=aa964c4b70f726491576302195664160bc4e0697fa73917207433ee9ff8bd07b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->