### PR TITLE
ci(release): fix back-merge PR stuck on protected branches (token + strict)

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -342,14 +342,31 @@ jobs:
     # directly (GH006: protected branch update failed) — instead we open a PR and let
     # it be reviewed/merged. The release commits are chore(release):, which do not
     # trigger a new release, so the back-merge PR is safe.
+    #
+    # IMPORTANT: the PR MUST be opened by a non-Actions identity. A PR opened with the
+    # default GITHUB_TOKEN does not emit a `pull_request` event (GitHub's recursion
+    # guard), so the required checks (test / security-scan / quality-checks) never run
+    # and the PR is stuck forever against branches with enforce_admins + required
+    # checks. SEMANTIC_RELEASE_TOKEN must therefore be a fine-grained PAT (Contents:write
+    # + Pull requests:write) or a GitHub App token — never the fallback GITHUB_TOKEN.
     - name: Back-merge release into develop and staging
       if: success() && steps.get_version.outputs.released_version != ''
       env:
+        SEMANTIC_RELEASE_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         RELEASED_VERSION: ${{ steps.get_version.outputs.released_version }}
       run: |
         set -euo pipefail
+
+        # Fail loudly instead of silently opening a PR that can never pass its checks.
+        if [ -z "${SEMANTIC_RELEASE_TOKEN}" ]; then
+          echo "::error title=Missing SEMANTIC_RELEASE_TOKEN::Back-merge aborted. A PR opened with the default GITHUB_TOKEN does not trigger the required pull_request checks, so it can never merge into the protected develop/staging branches. Configure a SEMANTIC_RELEASE_TOKEN secret (fine-grained PAT with Contents:write + Pull requests:write, or a GitHub App token)."
+          exit 1
+        fi
+
         git fetch origin main --quiet
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
         open_backmerge_pr() {
           local target="$1"
@@ -367,24 +384,43 @@ jobs:
             return 0
           fi
 
-          # Reuse an existing open back-merge PR instead of opening a duplicate.
+          # Deterministic head branch so reruns reuse (not duplicate) the PR.
+          local branch="chore/backmerge-${RELEASED_VERSION}-to-${target}"
           local existing
-          existing=$(gh pr list --base "$target" --head main --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          existing=$(gh pr list --base "$target" --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
           if [ -n "$existing" ]; then
             echo "ℹ️ Back-merge PR into '$target' already open: #$existing"
             return 0
           fi
 
+          # Build the head branch from main, then merge the target INTO it. This is
+          # what satisfies the branch protection "strict / require branches up to date"
+          # rule — a bare `--head main` is out-of-date whenever the target has moved on
+          # and would be blocked from merging even with checks green.
+          # main's only unique commits are chore(release): (version bump + CHANGELOG),
+          # so a conflict is unexpected; if one occurs, stop and let a human resolve it.
+          git checkout -B "$branch" origin/main
+          if ! git merge --no-edit "origin/$target"; then
+            git merge --abort || true
+            echo "::error title=Back-merge conflict::Merging '$target' into '$branch' hit a conflict. Resolve it manually and open the PR by hand."
+            return 1
+          fi
+          git push --force-with-lease origin "$branch"
+
           local url
           url=$(gh pr create \
             --base "$target" \
-            --head main \
+            --head "$branch" \
             --title "chore: back-merge release ${RELEASED_VERSION} into ${target}" \
             --body "Automated back-merge of release **${RELEASED_VERSION}** from \`main\` into \`${target}\` (version bump + CHANGELOG). Contains only \`chore(release)\` commits, so it will not trigger a new release.")
           echo "✅ Opened back-merge PR into '$target': $url"
           # Labels are best-effort (they may not exist in the repo).
           gh pr edit "$url" --add-label "automated" --add-label "version-sync" 2>/dev/null \
             || echo "(labels not applied — 'automated'/'version-sync' may not exist)"
+          # Auto-merge once the required checks pass (best-effort: needs "Allow
+          # auto-merge" enabled on the repo).
+          gh pr merge "$url" --auto --merge 2>/dev/null \
+            || echo "(auto-merge not enabled — merge the PR manually once checks pass)"
         }
 
         echo "🔄 Opening back-merge PR: main → develop..."


### PR DESCRIPTION
## Problem

The `semantic-release` workflow auto-opens a back-merge PR (`main` → `develop`/`staging`) using `GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}`. That secret does **not** exist, so it falls back to `GITHUB_TOKEN`.

A PR opened by `GITHUB_TOKEN` does not emit a `pull_request` event (GitHub's recursion guard), so `pr-checks.yml` (`test` / `security-scan` / `quality-checks (3.12)`) never runs. Both `develop` and `staging` have `enforce_admins: true` + those exact required checks, so the PR is **stuck forever** — no checks, no admin override.

Second, latent bug: the step opened the PR with `--head main`. With `strict: true` ("require branches up to date"), a bare `main` head is out-of-date whenever the target has moved on and is blocked from merging **even with checks green**. The last successful manual back-merge (#350) avoided this by merging the target into an intermediate branch first.

## Fix

- **Fail loudly** if `SEMANTIC_RELEASE_TOKEN` is unset, instead of silently creating a zombie PR.
- **Satisfy `strict`**: build a deterministic head branch `chore/backmerge-<ver>-to-<target>` from `main`, merge the target into it, then open the PR from that branch (aborts cleanly on the unexpected event of a conflict).
- **Close the loop**: enable `--auto` merge so the PR self-merges once checks pass.

## ⚠️ Required before this actually works (only a human can do this)

1. Create a **fine-grained PAT** scoped to `pyopenapi_gen` with **Contents: Read and write** + **Pull requests: Read and write**.
2. Add it as repo secret **`SEMANTIC_RELEASE_TOKEN`** (Settings → Secrets and variables → Actions).
3. Enable **Settings → General → Allow auto-merge** (for the `--auto` step).

Without step 1–2 the workflow now aborts the back-merge with a clear error rather than leaking a stuck PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mindhiveoy/codesmith/pyopenapi_gen/pr/352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786022315&installation_id=140942492&pr_number=352&repository=mindhiveoy%2Fpyopenapi_gen&return_to=https%3A%2F%2Fgithub.com%2Fmindhiveoy%2Fpyopenapi_gen%2Fpull%2F352&signature=a1f3bfc7a189a54499f1c2085e1b9dd46a9a24f61f888491b77ae4694fa996cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->