### PR TITLE
ci(release): promote back-merge fix to main (#352)

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -337,65 +337,60 @@ jobs:
         echo "released_version=$LATEST_TAG" >> $GITHUB_OUTPUT
         echo "Released version: $LATEST_TAG"
 
-    - name: Sync version to staging branch
+    # Back-merge the release commits (version bump + CHANGELOG) from main into the
+    # long-lived branches. develop/staging are protected, so we CANNOT push to them
+    # directly (GH006: protected branch update failed) — instead we open a PR and let
+    # it be reviewed/merged. The release commits are chore(release):, which do not
+    # trigger a new release, so the back-merge PR is safe.
+    - name: Back-merge release into develop and staging
       if: success() && steps.get_version.outputs.released_version != ''
       env:
         GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        RELEASED_VERSION: ${{ steps.get_version.outputs.released_version }}
       run: |
-        echo "🔄 Syncing main to staging branch..."
-        
-        # Fetch all branches
-        git fetch origin staging:staging || echo "Staging branch doesn't exist, skipping"
-        
-        if git show-ref --verify --quiet refs/heads/staging; then
-          # Switch to staging and merge main
-          git checkout staging
-          git merge main --no-edit || {
-            echo "⚠️ Merge conflict detected, creating PR instead"
-            git merge --abort
-            gh pr create \
-              --title "chore: sync version ${{ steps.get_version.outputs.released_version }} from main to staging" \
-              --body "Automated sync of semantic release version ${{ steps.get_version.outputs.released_version }} from main branch" \
-              --base staging \
-              --head main \
-              --label "automated,version-sync" || echo "PR may already exist"
-          } && {
-            echo "✅ Successfully merged main into staging"
-            git push origin staging || echo "Failed to push to staging"
-          }
-        else
-          echo "ℹ️ Staging branch doesn't exist, skipping sync"
-        fi
+        set -euo pipefail
+        git fetch origin main --quiet
 
-    - name: Sync version to develop branch  
-      if: success() && steps.get_version.outputs.released_version != ''
-      env:
-        GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
-      run: |
-        echo "🔄 Syncing main to develop branch..."
-        
-        # Fetch all branches
-        git fetch origin develop:develop || echo "Develop branch doesn't exist, skipping"
-        
-        if git show-ref --verify --quiet refs/heads/develop; then
-          # Switch to develop and merge main
-          git checkout develop
-          git merge main --no-edit || {
-            echo "⚠️ Merge conflict detected, creating PR instead"
-            git merge --abort
-            gh pr create \
-              --title "chore: sync version ${{ steps.get_version.outputs.released_version }} from main to develop" \
-              --body "Automated sync of semantic release version ${{ steps.get_version.outputs.released_version }} from main branch" \
-              --base develop \
-              --head main \
-              --label "automated,version-sync" || echo "PR may already exist"
-          } && {
-            echo "✅ Successfully merged main into develop"
-            git push origin develop || echo "Failed to push to develop"
-          }
-        else
-          echo "ℹ️ Develop branch doesn't exist, skipping sync"
-        fi
+        open_backmerge_pr() {
+          local target="$1"
+
+          if ! git ls-remote --exit-code --heads origin "$target" >/dev/null 2>&1; then
+            echo "ℹ️ '$target' branch doesn't exist, skipping"
+            return 0
+          fi
+
+          git fetch origin "$target" --quiet
+
+          # Nothing to do if the target already contains main's HEAD.
+          if git merge-base --is-ancestor origin/main "origin/$target"; then
+            echo "✅ '$target' already contains main, nothing to back-merge"
+            return 0
+          fi
+
+          # Reuse an existing open back-merge PR instead of opening a duplicate.
+          local existing
+          existing=$(gh pr list --base "$target" --head main --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$existing" ]; then
+            echo "ℹ️ Back-merge PR into '$target' already open: #$existing"
+            return 0
+          fi
+
+          local url
+          url=$(gh pr create \
+            --base "$target" \
+            --head main \
+            --title "chore: back-merge release ${RELEASED_VERSION} into ${target}" \
+            --body "Automated back-merge of release **${RELEASED_VERSION}** from \`main\` into \`${target}\` (version bump + CHANGELOG). Contains only \`chore(release)\` commits, so it will not trigger a new release.")
+          echo "✅ Opened back-merge PR into '$target': $url"
+          # Labels are best-effort (they may not exist in the repo).
+          gh pr edit "$url" --add-label "automated" --add-label "version-sync" 2>/dev/null \
+            || echo "(labels not applied — 'automated'/'version-sync' may not exist)"
+        }
+
+        echo "🔄 Opening back-merge PR: main → develop..."
+        open_backmerge_pr develop
+        echo "🔄 Opening back-merge PR: main → staging..."
+        open_backmerge_pr staging
 
     - name: Create release summary
       if: success()
@@ -406,7 +401,7 @@ jobs:
         echo "- **GitHub Release**: [Release Notes](https://github.com/mindhiveoy/pyopenapi_gen/releases/tag/${{ steps.get_version.outputs.released_version }})" >> $GITHUB_STEP_SUMMARY
         
         if [ -n "${{ steps.get_version.outputs.released_version }}" ]; then
-          echo "- **Branch Sync**: Version synced to staging and develop branches" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch Sync**: Back-merge PR(s) opened into develop/staging (review & merge to sync the version + CHANGELOG)" >> $GITHUB_STEP_SUMMARY
         fi
 
   notify-completion:

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -342,14 +342,31 @@ jobs:
     # directly (GH006: protected branch update failed) — instead we open a PR and let
     # it be reviewed/merged. The release commits are chore(release):, which do not
     # trigger a new release, so the back-merge PR is safe.
+    #
+    # IMPORTANT: the PR MUST be opened by a non-Actions identity. A PR opened with the
+    # default GITHUB_TOKEN does not emit a `pull_request` event (GitHub's recursion
+    # guard), so the required checks (test / security-scan / quality-checks) never run
+    # and the PR is stuck forever against branches with enforce_admins + required
+    # checks. SEMANTIC_RELEASE_TOKEN must therefore be a fine-grained PAT (Contents:write
+    # + Pull requests:write) or a GitHub App token — never the fallback GITHUB_TOKEN.
     - name: Back-merge release into develop and staging
       if: success() && steps.get_version.outputs.released_version != ''
       env:
+        SEMANTIC_RELEASE_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
         RELEASED_VERSION: ${{ steps.get_version.outputs.released_version }}
       run: |
         set -euo pipefail
+
+        # Fail loudly instead of silently opening a PR that can never pass its checks.
+        if [ -z "${SEMANTIC_RELEASE_TOKEN}" ]; then
+          echo "::error title=Missing SEMANTIC_RELEASE_TOKEN::Back-merge aborted. A PR opened with the default GITHUB_TOKEN does not trigger the required pull_request checks, so it can never merge into the protected develop/staging branches. Configure a SEMANTIC_RELEASE_TOKEN secret (fine-grained PAT with Contents:write + Pull requests:write, or a GitHub App token)."
+          exit 1
+        fi
+
         git fetch origin main --quiet
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
         open_backmerge_pr() {
           local target="$1"
@@ -367,24 +384,43 @@ jobs:
             return 0
           fi
 
-          # Reuse an existing open back-merge PR instead of opening a duplicate.
+          # Deterministic head branch so reruns reuse (not duplicate) the PR.
+          local branch="chore/backmerge-${RELEASED_VERSION}-to-${target}"
           local existing
-          existing=$(gh pr list --base "$target" --head main --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
+          existing=$(gh pr list --base "$target" --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null || echo "")
           if [ -n "$existing" ]; then
             echo "ℹ️ Back-merge PR into '$target' already open: #$existing"
             return 0
           fi
 
+          # Build the head branch from main, then merge the target INTO it. This is
+          # what satisfies the branch protection "strict / require branches up to date"
+          # rule — a bare `--head main` is out-of-date whenever the target has moved on
+          # and would be blocked from merging even with checks green.
+          # main's only unique commits are chore(release): (version bump + CHANGELOG),
+          # so a conflict is unexpected; if one occurs, stop and let a human resolve it.
+          git checkout -B "$branch" origin/main
+          if ! git merge --no-edit "origin/$target"; then
+            git merge --abort || true
+            echo "::error title=Back-merge conflict::Merging '$target' into '$branch' hit a conflict. Resolve it manually and open the PR by hand."
+            return 1
+          fi
+          git push --force-with-lease origin "$branch"
+
           local url
           url=$(gh pr create \
             --base "$target" \
-            --head main \
+            --head "$branch" \
             --title "chore: back-merge release ${RELEASED_VERSION} into ${target}" \
             --body "Automated back-merge of release **${RELEASED_VERSION}** from \`main\` into \`${target}\` (version bump + CHANGELOG). Contains only \`chore(release)\` commits, so it will not trigger a new release.")
           echo "✅ Opened back-merge PR into '$target': $url"
           # Labels are best-effort (they may not exist in the repo).
           gh pr edit "$url" --add-label "automated" --add-label "version-sync" 2>/dev/null \
             || echo "(labels not applied — 'automated'/'version-sync' may not exist)"
+          # Auto-merge once the required checks pass (best-effort: needs "Allow
+          # auto-merge" enabled on the repo).
+          gh pr merge "$url" --auto --merge 2>/dev/null \
+            || echo "(auto-merge not enabled — merge the PR manually once checks pass)"
         }
 
         echo "🔄 Opening back-merge PR: main → develop..."


### PR DESCRIPTION
Promote the hardened `semantic-release` back-merge step (#352) to `main`, where the release workflow actually runs.

**Release-safe:** 0 release-worthy commits (feat/fix/perf/BREAKING) since `v5.1.7` — only `ci`/merge commits — so this does **not** trigger a version bump or PyPI publish. It simply ships the fixed workflow so the *next* real release back-merges correctly.

Still required for the automated back-merge to fully work: create the `SEMANTIC_RELEASE_TOKEN` secret (fine-grained PAT) and enable "Allow auto-merge". Until then the back-merge step fails loudly instead of leaking a stuck PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mindhiveoy/codesmith/pyopenapi_gen/pr/353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786023141&installation_id=140942492&pr_number=353&repository=mindhiveoy%2Fpyopenapi_gen&return_to=https%3A%2F%2Fgithub.com%2Fmindhiveoy%2Fpyopenapi_gen%2Fpull%2F353&signature=e4d8b2357745ea10d6209aa9df86a712d23081ed7c4e62939dc17f599969a64a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->