### PR TITLE
chore: back-merge release v5.1.8 into develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyopenapi-gen"
-version = "5.1.7"
+version = "5.1.8"
 description = "Modern, async-first Python client generator for OpenAPI specifications with advanced cycle detection and unified type resolution"
 authors = [{ name = "Mindhive Oy", email = "contact@mindhive.fi" }]
 maintainers = [{ name = "Ville Venäläinen | Mindhive Oy", email = "ville@mindhive.fi" }]
@@ -143,7 +143,7 @@ pyopenapi-gen = "pyopenapi_gen.cli:app"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "5.1.7"
+version = "5.1.8"
 version_files = [
     "pyproject.toml:version",
     "src/pyopenapi_gen/__init__.py:__version__"

--- a/src/pyopenapi_gen/__init__.py
+++ b/src/pyopenapi_gen/__init__.py
@@ -54,7 +54,7 @@ __all__ = [
 ]
 
 # Semantic version of the generator core – automatically managed by semantic-release.
-__version__: str = "5.1.7"
+__version__: str = "5.1.8"
 
 # ---------------------------------------------------------------------------
 # Lazy-loading and autocompletion support (This part remains)


### PR DESCRIPTION
## Summary

Back-merges release **v5.1.8** from `main` into `develop`. Manual replacement for the automated back-merge, which aborted (see below).

Contains only the two `chore(release)` commits, so it will not trigger a new release:

- `c898d6a` chore(release): 5.1.8 — `pyproject.toml` version bump
- `94d1517` chore(release): sync __init__.py version

## Changes

```
 pyproject.toml                | 4 ++--
 src/pyopenapi_gen/__init__.py | 2 +-
```

`5.1.7` → `5.1.8` in all three tracked locations: `project.version`, `tool.commitizen.version`, and `__version__`. Merged as a clean fast-forward with no conflicts, so `main`'s commits become proper ancestors of `develop` and the next back-merge stays clean.

Verified locally: `scripts/validate_version_sync.py` reports all three locations synchronised at 5.1.8.

## Why the automation didn't do this

The `Back-merge release into develop and staging` step in run [30373966469](https://github.com/mindhiveoy/pyopenapi_gen/actions/runs/30373966469) failed deliberately:

> Back-merge aborted. A PR opened with the default GITHUB_TOKEN does not trigger the required `pull_request` checks, so it can never merge into the protected develop/staging branches. Configure a SEMANTIC_RELEASE_TOKEN secret (fine-grained PAT with Contents:write + Pull requests:write, or a GitHub App token).

`SEMANTIC_RELEASE_TOKEN` resolved empty in that run — the guard added in `559bb77` worked exactly as intended. **The release itself succeeded**: tag `v5.1.8` exists and 5.1.8 is live on PyPI. Only the back-merge was skipped.

To restore automation, configure the `SEMANTIC_RELEASE_TOKEN` repository secret. Until then, every release needs a manual back-merge like this one.

Note this PR is also missing the `staging` back-merge that the automation would have opened — `staging` should be checked separately.

## ⚠️ Separate pre-existing issue: CHANGELOG.md is not being generated

There is **no changelog content to back-merge**, because the release never produced any. `chore(release): 5.1.8` touched only `pyproject.toml`; `CHANGELOG.md` was not modified, and the release log shows no changelog activity.

`CHANGELOG.md` is stale at **v0.23.1 (2025-11-07)** — the last commit to touch it was `b0a2a62 chore(release): 0.23.1`. Every release from 0.23.1 through 5.1.8 has left it untouched.

The likely cause is v7/v8-era config keys under `[tool.semantic_release]` that python-semantic-release v10 no longer reads:

```toml
changelog_file = "CHANGELOG.md"      # v10 expects this under [tool.semantic_release.changelog]
changelog_format = "# Changelog\n\n{changelog}"
branch = "main"                      # v10 uses [tool.semantic_release.branches.*]
upload_to_pypi = false               # v7-era
upload_to_repository = false         # v7-era
```

Worth fixing separately — it needs a config migration and a verification run, and it would ideally backfill the ~5 versions of missing entries. Out of scope here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mindhiveoy/codesmith/pyopenapi_gen/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787845674&installation_model_id=424599&pr_number=369&repository=mindhiveoy%2Fpyopenapi_gen&return_to=https%3A%2F%2Fgithub.com%2Fmindhiveoy%2Fpyopenapi_gen%2Fpull%2F369&signature=7bf7c406c6138631c315baabb04e76d1c291ab19c46909ddab6e9ab258af88e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->