### PR TITLE
fix(release): make semantic-release and back-merge work unattended

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,20 @@ updates:
       - "pyopenapi-team"
     assignees:
       - "pyopenapi-team"
+    # Prefixes MUST be conventional-commit types that python-semantic-release
+    # recognises, otherwise dependency merges never produce a release. The old
+    # "deps"/"deps-dev" prefixes are not conventional types at all, so the parser
+    # ignored them entirely — which is why dependency-only merges silently never
+    # released and needed a hand-written trigger commit. Dependabot appends the
+    # scope, producing "fix(deps): ..." and "fix(deps-dev): ...", both of which
+    # map to a patch bump.
+    #
+    # To stop dev-only bumps (ruff, mypy, pytest — nothing that reaches the
+    # published package) from cutting releases, change prefix-development to
+    # "chore".
     commit-message:
-      prefix: "deps"
-      prefix-development: "deps-dev"
+      prefix: "fix"
+      prefix-development: "fix"
     labels:
       - "dependencies"
       - "automated"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -337,32 +337,55 @@ jobs:
         echo "released_version=$LATEST_TAG" >> $GITHUB_OUTPUT
         echo "Released version: $LATEST_TAG"
 
+    # Mint a short-lived GitHub App installation token for the back-merge.
+    #
+    # This is the ONLY identity that makes the back-merge work. A PR opened with the
+    # default GITHUB_TOKEN does not emit a `pull_request` event (GitHub's recursion
+    # guard), so develop's required checks (test / security-scan / quality-checks)
+    # never run and the PR can never merge past enforce_admins + required checks.
+    #
+    # App tokens are minted per run and expire in ~1h, so unlike a PAT there is no
+    # expiry date to silently break the pipeline months later.
+    #
+    # Setup (one time): create a GitHub App in the org with repository permissions
+    # Contents: read & write + Pull requests: read & write, install it on this repo,
+    # then add secrets RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY.
+    - name: Mint GitHub App token for back-merge
+      id: app_token
+      if: ${{ success() && steps.get_version.outputs.released_version != '' && secrets.RELEASE_APP_ID != '' }}
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ secrets.RELEASE_APP_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
     # Back-merge the release commits (version bump + CHANGELOG) from main into the
     # long-lived branches. develop/staging are protected, so we CANNOT push to them
     # directly (GH006: protected branch update failed) — instead we open a PR and let
-    # it be reviewed/merged. The release commits are chore(release):, which do not
-    # trigger a new release, so the back-merge PR is safe.
-    #
-    # IMPORTANT: the PR MUST be opened by a non-Actions identity. A PR opened with the
-    # default GITHUB_TOKEN does not emit a `pull_request` event (GitHub's recursion
-    # guard), so the required checks (test / security-scan / quality-checks) never run
-    # and the PR is stuck forever against branches with enforce_admins + required
-    # checks. SEMANTIC_RELEASE_TOKEN must therefore be a fine-grained PAT (Contents:write
-    # + Pull requests:write) or a GitHub App token — never the fallback GITHUB_TOKEN.
+    # it be auto-merged once checks pass. The release commits are chore(release):,
+    # which do not trigger a new release, so the back-merge PR is safe.
     - name: Back-merge release into develop and staging
       if: success() && steps.get_version.outputs.released_version != ''
       env:
-        SEMANTIC_RELEASE_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-        GH_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        # App token preferred; SEMANTIC_RELEASE_TOKEN (fine-grained PAT) still works as
+        # a fallback so an existing PAT setup keeps functioning. GITHUB_TOKEN is never
+        # acceptable here — see the guard below.
+        BACKMERGE_TOKEN: ${{ steps.app_token.outputs.token || secrets.SEMANTIC_RELEASE_TOKEN }}
+        GH_TOKEN: ${{ steps.app_token.outputs.token || secrets.SEMANTIC_RELEASE_TOKEN }}
         RELEASED_VERSION: ${{ steps.get_version.outputs.released_version }}
       run: |
         set -euo pipefail
 
         # Fail loudly instead of silently opening a PR that can never pass its checks.
-        if [ -z "${SEMANTIC_RELEASE_TOKEN}" ]; then
-          echo "::error title=Missing SEMANTIC_RELEASE_TOKEN::Back-merge aborted. A PR opened with the default GITHUB_TOKEN does not trigger the required pull_request checks, so it can never merge into the protected develop/staging branches. Configure a SEMANTIC_RELEASE_TOKEN secret (fine-grained PAT with Contents:write + Pull requests:write, or a GitHub App token)."
+        if [ -z "${BACKMERGE_TOKEN}" ]; then
+          echo "::error title=No elevated token for back-merge::Back-merge aborted. A PR opened with the default GITHUB_TOKEN does not trigger the required pull_request checks, so it can never merge into the protected develop/staging branches. Configure a GitHub App (secrets RELEASE_APP_ID + RELEASE_APP_PRIVATE_KEY, with Contents:write + Pull requests:write) — or, as a fallback, a SEMANTIC_RELEASE_TOKEN fine-grained PAT."
           exit 1
         fi
+
+        # Push the back-merge branch as the elevated identity too. actions/checkout
+        # persisted the *release* credentials (GITHUB_TOKEN when no PAT is set), and a
+        # branch pushed under that identity is a dead end for auto-merge.
+        git remote set-url origin \
+          "https://x-access-token:${BACKMERGE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
         git fetch origin main --quiet
         git config user.name "github-actions[bot]"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -350,9 +350,13 @@ jobs:
     # Setup (one time): create a GitHub App in the org with repository permissions
     # Contents: read & write + Pull requests: read & write, install it on this repo,
     # then add secrets RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY.
+    # continue-on-error so that a missing/invalid App config does not abort here with an
+    # opaque action failure. The token comes out empty, and the guard in the next step
+    # reports what to configure. Also keeps a PAT-only setup working untouched.
     - name: Mint GitHub App token for back-merge
       id: app_token
-      if: ${{ success() && steps.get_version.outputs.released_version != '' && secrets.RELEASE_APP_ID != '' }}
+      if: success() && steps.get_version.outputs.released_version != ''
+      continue-on-error: true
       uses: actions/create-github-app-token@v2
       with:
         app-id: ${{ secrets.RELEASE_APP_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,2502 @@
 # CHANGELOG
 
+<!-- version list -->
+
+## v5.1.8 (2026-07-28)
+
+### Bug Fixes
+
+- **deps**: Update dependencies to latest compatible versions
+  ([`3f02cb3`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3f02cb31cdde524116dfa02cbb06d83c9c3732ea))
+
+### Chores
+
+- **deps**: Consolidate open dependabot updates
+  ([`f98db99`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f98db99bd00f077be62f570711da5e735657f54a))
+
+- **deps**: Update remaining packages to latest compatible versions
+  ([`0254df0`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0254df0f9fdc3b630d2a51d5f247107dd42ab93c))
+
+- **release**: Sync __init__.py version
+  ([`b9f4207`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b9f4207cd5bdac5204036783320c52cdec9a9ff0))
+
+### Continuous Integration
+
+- **release**: Harden back-merge PR (require elevated token, satisfy strict, auto-merge)
+  ([`559bb77`](https://github.com/mindhiveoy/pyopenapi_gen/commit/559bb7738d0cb9f520d58b2d704eb17a2c58d069))
+
+
+## v5.1.7 (2026-07-07)
+
+### Bug Fixes
+
+- Pass Ruff bulk targets via response files
+  ([`cd0f263`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cd0f2634acdb00f052f89fe8ee672988c360c5c7))
+
+- **endpoints**: Raise for default-response error codes instead of masking
+  ([`89667e4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/89667e40496073bb96843d0383ca48abf54b4dd3))
+
+- **transport**: Do not raise HTTPError on non-2xx responses
+  ([`f8422aa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f8422aa76783b33b16750d981f4e22a64ef131f0))
+
+### Chores
+
+- **deps**: Consolidate dependabot package updates
+  ([`5f08372`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5f08372d037a60a586fa14236e8b32fe9c493547))
+
+- **deps**: Replace safety with pip-audit to drop vulnerable nltk
+  ([`6faec80`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6faec80702218502375da989eef26872a677802d))
+
+- **release**: Sync __init__.py version
+  ([`6a03c4b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6a03c4b3fb649f8e54bb5ec8fb6e278f28523620))
+
+### Continuous Integration
+
+- **release**: Back-merge release into develop/staging via PR
+  ([`3492c51`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3492c514a673ac2f4d19a6b8978d123af11e3173))
+
+### Testing
+
+- Cover optional security requirements
+  ([`c26a786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c26a78651fef042fbd3a35cad2c72eea74504851))
+
+- **transport**: Cover full status-code to exception pipeline at runtime
+  ([`d2fd83d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d2fd83dddf2285bb9782e90c1d6440b4ba554f31))
+
+
+## v5.1.6 (2026-03-08)
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`0b900c0`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0b900c0f4bd9a2302ec329ca75c74fa8fd067078))
+
+### Performance Improvements
+
+- **converter**: Eliminate O(N×calls) get_type_hints traversal with module-level caching
+  ([`ebefac9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ebefac9947b7bf440957aab09b70cc0f62e08601))
+
+
+## v5.1.5 (2026-03-08)
+
+### Bug Fixes
+
+- **converter**: Preserve Annotated discriminator in nested dataclass fields
+  ([#308](https://github.com/mindhiveoy/pyopenapi_gen/pull/308),
+  [`5114aad`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5114aadcead0d239a929e0464322df9a741069d5))
+
+- **converter**: Preserve Annotated discriminator in nested dataclass fields (#308)
+  ([#309](https://github.com/mindhiveoy/pyopenapi_gen/pull/309),
+  [`382d647`](https://github.com/mindhiveoy/pyopenapi_gen/commit/382d647fca82601a2767d2aaa17bb5354440500d))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`6fb5eea`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6fb5eeab9b700e8ebc8aa1bbe83098d2ebc9a427))
+
+
+## v5.1.4 (2026-03-07)
+
+### Bug Fixes
+
+- **renderer**: Sanitize schema names in discriminator mapping generation
+  ([`2f43161`](https://github.com/mindhiveoy/pyopenapi_gen/commit/2f4316190e8cb46211392ed2264a4293bdc69a0f))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`c3799e6`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c3799e64fd92d2c46b2c847044b8ec7c8309ed3f))
+
+
+## v5.1.3 (2026-03-03)
+
+### Bug Fixes
+
+- Resolve literal \n in __init__.py and circular imports in models
+  ([`8986197`](https://github.com/mindhiveoy/pyopenapi_gen/commit/89861978f6ca07c7dffd04864a240c35604aff1d))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`4ca07ea`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4ca07eabd3e9a869549b3cf69226259fcd5c63c0))
+
+
+## v5.1.2 (2026-02-24)
+
+### Bug Fixes
+
+- **parser**: Remove over-broad component parameter fallback that caused name collisions
+  ([`23a8092`](https://github.com/mindhiveoy/pyopenapi_gen/commit/23a8092c91eb6da0c1428d62a29bbdb4dff40013))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`974f548`](https://github.com/mindhiveoy/pyopenapi_gen/commit/974f548a54783e6848a3caffbdd78737e6a0f460))
+
+
+## v5.1.1 (2026-02-13)
+
+### Bug Fixes
+
+- **emitter**: Prevent empty model files with TypeAlias fallback guard
+  ([`0b88c84`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0b88c847b80622cd91c32115148efbb25c102dab))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`c54a600`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c54a6007e55f6924bb546d1e3662f35805813e3d))
+
+
+## v5.1.0 (2026-02-10)
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`27a8846`](https://github.com/mindhiveoy/pyopenapi_gen/commit/27a8846773bd13f8fa24c570eb1bd2e6165cc458))
+
+### Features
+
+- **naming**: Add --naming-strategy CLI option for method name derivation
+  ([`89a90ad`](https://github.com/mindhiveoy/pyopenapi_gen/commit/89a90ade6749de3ba2fac726a7a09438d08feadf))
+
+
+## v5.0.5 (2026-02-06)
+
+### Bug Fixes
+
+- **converter**: Register key transform hooks for generic container types
+  ([`0ef725b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0ef725bc3d1bfab8c5ed8b860acc75ed643be9bb))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`53a91d5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/53a91d5a004d6a9cecfb64015d2f4cc7a2067eeb))
+
+
+## v5.0.4 (2026-02-06)
+
+### Bug Fixes
+
+- **parser**: Prevent shared IRSchema corruption in discriminator enum collector
+  ([`e93e035`](https://github.com/mindhiveoy/pyopenapi_gen/commit/e93e0357e6e04cf2238a8ae05047712e0826db69))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`9816e70`](https://github.com/mindhiveoy/pyopenapi_gen/commit/9816e70c0846bae195cb4c5a7303a84a1e5978da))
+
+
+## v5.0.3 (2026-01-28)
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`86d22a9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/86d22a94d0d13510daf50fd9308c9fbe29c830fb))
+
+
+## v5.0.2 (2026-01-28)
+
+### Bug Fixes
+
+- **discriminator**: Add mapping fallback for shared enum values
+  ([`565525f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/565525fbe0a821a2b39317a386a8fbe2a79b42b1))
+
+- **discriminator**: Resolve enum values via schema references
+  ([`481ca25`](https://github.com/mindhiveoy/pyopenapi_gen/commit/481ca25fd0da133e2be4fa9106eaa81e2db1d7fe))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`f51f356`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f51f3562dfa34ed8932f5e6a2d4e4210ca06c464))
+
+
+## v5.0.1 (2026-01-28)
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`b7d0a41`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b7d0a41379ae4f2af647202c1024c67e35144baa))
+
+
+## v5.0.0 (2026-01-27)
+
+### Bug Fixes
+
+- **core**: Add circular reference protection to DataclassSerializer
+  ([`55578f0`](https://github.com/mindhiveoy/pyopenapi_gen/commit/55578f081ac35c18ff8742f24f536d3940f9831d))
+
+- **core**: Update final_module_stem for discriminator enum properties
+  ([`b987fa6`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b987fa6acc2812082fbd522d758584ed5e3b1ba4))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`d2598d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d2598d45f4d3db438bb074254ec1c8aebeb92e32))
+
+### Features
+
+- **core**: Generate unified enums for discriminated unions
+  ([`691bcda`](https://github.com/mindhiveoy/pyopenapi_gen/commit/691bcda3275f0aa019c0d3fb1d343d2386b230da))
+
+### Breaking Changes
+
+- **core**: Discriminated union discriminator properties now generate a single unified enum instead
+  of multiple single-value enums.
+
+
+## v4.0.0 (2026-01-22)
+
+### Bug Fixes
+
+- **types**: Preserve OpenAPI anyOf/oneOf order in Union types
+  ([`256da40`](https://github.com/mindhiveoy/pyopenapi_gen/commit/256da40a4de2628e3f920badb0ab2ad5f6c0f925))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`1c1afee`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1c1afee4187111b51c30934016c2b3d64ed852c0))
+
+### Breaking Changes
+
+- **types**: Generated Union types now preserve OpenAPI anyOf/oneOf order instead of alphabetical
+  sorting. This is semantically equivalent but may affect code that relied on sorted order.
+
+
+## v3.0.2 (2026-01-22)
+
+### Bug Fixes
+
+- **core**: Simplify DataclassSerializer by delegating to cattrs
+  ([`d586300`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d586300b4bcb19e904a7705935746f767952c085))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`f6cca64`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f6cca64aef2812b29bb41e3b5a306ca64234bfc1))
+
+
+## v3.0.1 (2026-01-22)
+
+### Bug Fixes
+
+- **core**: Respect cattrs unstructure hooks in DataclassSerializer
+  ([`cfb4ba9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cfb4ba9a30f209428c192ccefa572826a6061c3b))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`fdd5dc7`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdd5dc710974b59db47736bea34d9d22b2728176))
+
+
+## v3.0.0 (2026-01-14)
+
+### Bug Fixes
+
+- **parser**: Resolve schema registration and enum naming issues
+  ([`5acf246`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5acf2462860702593964c8a052c65b537ff180d5))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`a705bcd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/a705bcdb1b8fa9b790da0fa6c3bf599c7fdf96e9))
+
+### Code Style
+
+- Apply black formatting to python_construct_renderer.py
+  ([`ab95807`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ab95807bd0dd46946d003ec52bdab9e01e118438))
+
+### Breaking Changes
+
+- **parser**: Schema registration now uses sanitized names consistently
+
+
+## v2.7.5 (2026-01-13)
+
+### Bug Fixes
+
+- **emitters**: Ensure oneOf/anyOf/allOf variants get generation names
+  ([`5dfe6db`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5dfe6db9a949ff54f8a30a481890616dc147833e))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`0d73483`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0d734835294cfd20a3247280435ff367b805aa89))
+
+
+## v2.7.4 (2026-01-13)
+
+### Bug Fixes
+
+- **release**: Prevent semantic-release failures from verbose dependency commits
+  ([`e0eaa59`](https://github.com/mindhiveoy/pyopenapi_gen/commit/e0eaa5944fdb99515eed827373a9e6936625a864))
+
+
+## v2.7.3 (2026-01-13)
+
+### Bug Fixes
+
+- **visitor**: Generate Union type alias for oneOf/anyOf discriminated unions
+  ([`1f991f3`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1f991f3b5804bf6f63a731214649eff34edd2ed5))
+
+### Chores
+
+- **deps**: Update dependencies in poetry.lock
+  ([`7478a46`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7478a4666dc6fe9690d29d017b11cab9b04d0044))
+
+- **release**: Sync __init__.py version
+  ([`960ed74`](https://github.com/mindhiveoy/pyopenapi_gen/commit/960ed74f4c1e77e3598edc9cf0c690f19c82a5b9))
+
+
+## v2.7.2 (2025-12-29)
+
+### Bug Fixes
+
+- Correct spelling of "deserialization" and "sanitized" in comments and docstrings
+  ([`f7c533c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f7c533c83248c59c9a002cb4e6ed10c9bcf9bb23))
+
+- Register cattrs hooks for additionalProperties wrapper classes
+  ([`850fa04`](https://github.com/mindhiveoy/pyopenapi_gen/commit/850fa04dc30de60f045365ddbf9589738557116b))
+
+### Chores
+
+- Add comprehensive documentation for code review, generation, quality checks, and dependency
+  management
+  ([`32dcd79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/32dcd79a2bf3bd3def3d5a519b543bf5de203825))
+
+- **release**: Sync __init__.py version
+  ([`42fa469`](https://github.com/mindhiveoy/pyopenapi_gen/commit/42fa469f2fc8e5b52b91de47846c2d76964c1349))
+
+
+## v2.7.1 (2025-12-29)
+
+### Bug Fixes
+
+- Handle boolean enums and typeless array items correctly
+  ([`0509db9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0509db97ba1aca5808153c360ba79a4814cb1911))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`d8dee0c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d8dee0c87641b017889524cdb9f127cd9beabc0a))
+
+
+## v2.7.0 (2025-12-27)
+
+### Bug Fixes
+
+- **codegen**: Consistent array item type generation and inline enum extraction
+  ([`d9fc953`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d9fc953b9b6d77237c9415260ea9891261f1a0d7))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`e925222`](https://github.com/mindhiveoy/pyopenapi_gen/commit/e925222bb64b696d2a0fb1f095d90a2ad63bb288))
+
+### Documentation
+
+- Synchronise documentation with implementation
+  ([`be1ad98`](https://github.com/mindhiveoy/pyopenapi_gen/commit/be1ad98d16319eadfdc7c1ab1c1126d595fa1a49))
+
+### Features
+
+- **formats**: Add extended OpenAPI format mappings
+  ([`4e041e8`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4e041e83d56dde485acd5c0ca77423b3dc54c35f))
+
+### Testing
+
+- Fix max_depth expectation in all_of_parser test
+  ([`d808e48`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d808e48b76fd779761b65e21c7b4ebd8229180bb))
+
+
+## v2.6.5 (2025-12-23)
+
+### Bug Fixes
+
+- **cattrs**: Improve union error messages and typed wrapper deserialisation
+  ([`443c97c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/443c97c4c6ddd49d1ba83ae2d3ba4d0cb5af3204))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`a204cc5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/a204cc555d3e7036bda89519649090395f9c62a8))
+
+
+## v2.6.4 (2025-12-23)
+
+### Bug Fixes
+
+- Deserialise typed additionalProperties values into proper types
+  ([`0fb31d7`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0fb31d77607ebef0d1e34274ed365a120ff265ba))
+
+- **deps**: Update dependencies and resolve werkzeug CVE-2025-66221
+  ([`4c33868`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c33868d198195f75eac3b68f21aaa5064d5a3a8))
+
+- **deps**: Update werkzeug to 3.1.4 for CVE-2025-66221
+  ([`faf39ef`](https://github.com/mindhiveoy/pyopenapi_gen/commit/faf39efc84fb29305e5a18794871256b07b9f402))
+
+- **security**: Add explicit permissions to GitHub workflows
+  ([`9d97d49`](https://github.com/mindhiveoy/pyopenapi_gen/commit/9d97d4915e77e8b5e2e23f7ecb62722e116eaa13))
+
+- **security**: Remove dead code with ReDoS vulnerability
+  ([`1483ea1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1483ea1702ccccd8d4a5b36c6101a81833d36468))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`73b2525`](https://github.com/mindhiveoy/pyopenapi_gen/commit/73b2525a32bc9c2a8fc6f2b40bc82a147eca813c))
+
+
+## v2.6.3 (2025-12-18)
+
+### Bug Fixes
+
+- **generator**: Convert camelCase params to snake_case in overloaded endpoints
+  ([`0e1d68a`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0e1d68a886ed897edb539aaa896c152c6bfd6cce))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`d97ef9c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d97ef9ccc6d232a002fb2a55d7cca04a2cb4e6b8))
+
+
+## v2.6.2 (2025-12-18)
+
+### Bug Fixes
+
+- **serializer**: Add base64 encoding for bytes in DataclassSerializer
+  ([`4b5ced2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4b5ced27ee7bd08d93764a17a84637c9d7c38d86))
+
+### Chores
+
+- Update .gitignore to include coverage.json and new project coordination files
+  ([`16c3ee5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/16c3ee5fa1e61badbe8f403e3c25c44fb201b692))
+
+- **release**: Sync __init__.py version
+  ([`10734f0`](https://github.com/mindhiveoy/pyopenapi_gen/commit/10734f0e5ddd044d86f1bcb3c633a20201d1defd))
+
+### Refactoring
+
+- Streamline CLAUDE.md for clarity and organization
+  ([`653c41c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/653c41caf639bfd92fa5969ea1116284c0a547ee))
+
+
+## v2.6.1 (2025-12-15)
+
+### Bug Fixes
+
+- **codegen**: Preserve original API field names and detect collisions
+  ([`f412351`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f4123510f4b402c9cee55d0d60d3f8b70be7b96e))
+
+### Chores
+
+- **release**: Sync __init__.py version
+  ([`7945ac3`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7945ac316218d170fbf2200e9d27cd0769369332))
+
+
+## v2.6.0 (2025-12-15)
+
+### Bug Fixes
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- Release develop with batch dependency updates and security fixes
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- Release develop with batch dependency updates and security fixes
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **cattrs**: Handle null values in structure hooks
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+### Chores
+
+- Sync main (v2.0.3 release) into develop
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- Sync main (v2.0.3 release) into develop
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- Sync main (v2.0.3 release) into develop
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- Sync main (v2.0.3 release) into develop
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- Sync main (v2.0.3 release) into develop
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- Sync main (v2.0.3 release) into develop
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- Sync main (v2.0.3 release) into develop
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- Sync main (v2.0.3 release) into develop
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- Sync main (v2.0.3 release) into develop
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- Sync version 2.0.1 from main to develop
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- Sync version 2.0.1 from main to develop
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- Sync version 2.0.1 from main to develop
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- Sync version 2.0.1 from main to develop
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- Sync version 2.0.1 from main to develop
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- Sync version 2.0.1 from main to develop
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- Sync version 2.0.1 from main to develop
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- Sync version 2.0.1 from main to develop
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- Sync version 2.0.1 from main to develop
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- Update IDE settings and test swagger file
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **deps**: Batch update dependencies ([#186](https://github.com/mindhiveoy/pyopenapi_gen/pull/186),
+  [`d692306`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6923068e3cc11eb599fbb5d02758b3a70a144ca))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **release**: Sync __init__.py version
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **release**: Sync __init__.py version
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **release**: Sync __init__.py version
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **release**: Sync __init__.py version
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **release**: Sync __init__.py version
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **release**: Sync __init__.py version
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **release**: Sync __init__.py version
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **release**: Sync __init__.py version
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **release**: Sync __init__.py version
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **release**: Sync __init__.py version
+  ([`370ef24`](https://github.com/mindhiveoy/pyopenapi_gen/commit/370ef24a43414bae94f8acc5d00bd7b4e3608073))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **release**: Sync __init__.py versio…
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **release**: Sync __init__.py versio…
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **release**: Sync __init__.py vers… ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **release**: Sync __init__.py vers… ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **release**: Sync __init__.p… ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **release**: Sync __init__.p… ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **release**: Sync __init__.p… ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **sync**: Merge main into develop to resolve conflicts
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **sync**: Merge main v2.3.0 release into develop
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **sync**: Merge main v2.4.0 into develop
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **sync**: Merge main v2.5.0 release into develop
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **sync**: Merge remote develop changes
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+### Continuous Integration
+
+- Bump actions/cache from 4 to 5 ([#174](https://github.com/mindhiveoy/pyopenapi_gen/pull/174),
+  [`735b8c9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/735b8c9ec344bf14881a0d06b5ca4c570fe8aac7))
+
+### Documentation
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+### Features
+
+- Improve `cattrs_converter`'s support for future annotations and error reporting, and add enum
+  default value handling to `dataclass_generator`.
+  ([#159](https://github.com/mindhiveoy/pyopenapi_gen/pull/159),
+  [`c6ba271`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c6ba271bdf97183e795a6d447768e43940efe4f8))
+
+- Release develop to main with SSL verification and cattrs improvements
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- Release develop to main with SSL verification and cattrs improvements
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- Release develop to main with SSL verification and cattrs improvements
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **cattrs**: Add Union type structure hook for oneOf/anyOf schemas
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **cattrs**: Add union type structure hook for oneOf/anyOf support
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **cattrs**: Add union type structure hook for oneOf/anyOf support
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **cli**: Add URL support for loading OpenAPI specifications
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+- **transport**: Add verify_ssl parameter and fix cattrs null handling
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **transport**: Add verify_ssl parameter to HttpxTransport
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+### Performance Improvements
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#190](https://github.com/mindhiveoy/pyopenapi_gen/pull/190),
+  [`3996752`](https://github.com/mindhiveoy/pyopenapi_gen/commit/39967528238e1173f483d727cacb960e0ef01aca))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#189](https://github.com/mindhiveoy/pyopenapi_gen/pull/189),
+  [`c33c4a1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c33c4a109ad10282537db77791e4a345e923273a))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#184](https://github.com/mindhiveoy/pyopenapi_gen/pull/184),
+  [`d6ada2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d6ada2d8ac6792a627ae901086e0dae1902f31ee))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#182](https://github.com/mindhiveoy/pyopenapi_gen/pull/182),
+  [`19df388`](https://github.com/mindhiveoy/pyopenapi_gen/commit/19df388d05ad09ca6c10a1ec764bb258003d7db7))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#180](https://github.com/mindhiveoy/pyopenapi_gen/pull/180),
+  [`bce6e79`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bce6e79d58862af9c6d2159e668f5a21746241c0))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#164](https://github.com/mindhiveoy/pyopenapi_gen/pull/164),
+  [`29791dd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/29791dd4bb11c8c24fdbe7712cdf39b4be5ebe68))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#162](https://github.com/mindhiveoy/pyopenapi_gen/pull/162),
+  [`aab0ebd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aab0ebd38454d13a8de1cd17fac5c69bf703011b))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#161](https://github.com/mindhiveoy/pyopenapi_gen/pull/161),
+  [`3aafdde`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3aafddef3e64cc5fa080758c154c5e9417d72c40))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#155](https://github.com/mindhiveoy/pyopenapi_gen/pull/155),
+  [`d5fa8ec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5fa8ece771ebbc9b2aeab4a04e13b6430d697b4))
+
+
+## v2.5.0 (2025-12-15)
+
+### Bug Fixes
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- Release develop with batch dependency updates and security fixes
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Implement generic camelCase/snake_case field mapping for catt…
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Implement generic camelCase/snake_case field mapping for catt…
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Implement generic camelCase/snake_case field mapping for ca…
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Implement generic camelCase/snake_case field mapping for ca…
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Implement generic camelCase/snake_case field mapping…
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Implement generic camelCase/snake_case field mapping…
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Implement generic camelCase/snake_case field mappin…
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Implement generic camelCase/snake_case field mappin…
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Implement generic camelCase/snake_case field …
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Implement generic camelCase/snake_case field …
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Implement generic camelCase/snake_c…
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Implement generic camelCase/snake_c…
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Implement generic camelCase/snak…
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Implement generic camelCase/snak…
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+### Chores
+
+- Sync main (v2.0.3 release) into develop
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- Sync main (v2.0.3 release) into develop
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- Sync version 2.0.1 from main to develop
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- Sync version 2.0.1 from main to develop
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **deps**: Batch update dependencies ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **release**: Sync __init__.py version
+  ([`d2c1941`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d2c194149d49dd8ca6bc63dd7f7b36412a2eae9f))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **sync**: Merge main into develop to resolve conflicts
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **sync**: Merge main into develop to resolve conflicts
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **sync**: Merge main v2.3.0 release into develop
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **sync**: Merge main v2.3.0 release into develop
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **sync**: Merge main v2.4.0 into develop
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **sync**: Merge main v2.4.0 into develop
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **sync**: Merge remote develop changes
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **sync**: Merge remote develop changes
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+### Code Style
+
+- Fix extra blank line in cattrs_converter.py
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+### Continuous Integration
+
+- Bump actions/cache from 4 to 5 ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- Bump actions/cache from 4 to 5 ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+### Documentation
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+### Features
+
+- Improve `cattrs_converter`'s support for future annotations and error reporting, and add enum
+  default value handling to `dataclass_generator`.
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- Improve `cattrs_converter`'s support for future annotations and error reporting, and add enum
+  default value handling to `dataclass_generator`.
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **cattrs**: Add Union type structure hook for oneOf/anyOf schemas
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **cattrs**: Add Union type structure hook for oneOf/anyOf schemas
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **cattrs**: Add union type structure hook for oneOf/anyOf support
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+- **transport**: Add verify_ssl parameter and fix cattrs null handling
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **transport**: Add verify_ssl parameter and fix cattrs null handling
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+### Performance Improvements
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#188](https://github.com/mindhiveoy/pyopenapi_gen/pull/188),
+  [`88979c4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/88979c449471cf0d3b8d50e234d601670d48b46c))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#185](https://github.com/mindhiveoy/pyopenapi_gen/pull/185),
+  [`6e498fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e498fa986ac24b25d5707a0c87c9b5d11841d02))
+
+
+## v2.4.0 (2025-11-28)
+
+### Bug Fixes
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **core**: Implement generic camelCase/snake_case field mapping…
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **core**: Implement generic camelCase/snake_case field mappin…
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **core**: Implement generic camelCase/snake_case field …
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **core**: Implement generic camelCase/snak…
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+### Chores
+
+- Sync main (v2.0.3 release) into develop
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- Sync version 2.0.1 from main to develop
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **release**: Sync __init__.py version
+  ([`7401e91`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7401e915ace09d3b8282a56c5a96a7f433023268))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **sync**: Merge main into develop to resolve conflicts
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **sync**: Merge main v2.3.0 release into develop
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+### Documentation
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+### Features
+
+- Improve `cattrs_converter`'s support for future annotations and error reporting, and add enum
+  default value handling to `dataclass_generator`.
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- Release develop to main with SSL verification and cattrs improvements
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+- **transport**: Add verify_ssl parameter and fix cattrs null handling
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+### Performance Improvements
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#165](https://github.com/mindhiveoy/pyopenapi_gen/pull/165),
+  [`6e07be2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e07be219b50c8928638a5e92c2f1b609ddeff5a))
+
+
+## v2.3.0 (2025-11-24)
+
+### Bug Fixes
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **core**: Implement generic camelCase/snake_case field mapping…
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+### Chores
+
+- Sync main (v2.0.3 release) into develop
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- Sync version 2.0.1 from main to develop
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **release**: Sync __init__.py version
+  ([`b619550`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b61955048937347c7b7e445ac093cdccb9d6afe5))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **sync**: Sync develop with main v2.2.0 release
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+### Documentation
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+### Features
+
+- Improve `cattrs_converter`'s support for future annotations and error reporting, and add enum
+  default value handling to `dataclass_generator`.
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+### Performance Improvements
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#160](https://github.com/mindhiveoy/pyopenapi_gen/pull/160),
+  [`7588579`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7588579235b186252e1d194168a6368d67016e87))
+
+
+## v2.2.0 (2025-11-20)
+
+### Bug Fixes
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#139](https://github.com/mindhiveoy/pyopenapi_gen/pull/139),
+  [`7faf179`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7faf179bf9994c32353f42a3b510a64486fb9fdb))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([`2031708`](https://github.com/mindhiveoy/pyopenapi_gen/commit/203170849ad589b2198de88f220f3a104d24bf0e))
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **ci**: Allow workflow_dispatch to bypass commit message skip checks
+  ([#151](https://github.com/mindhiveoy/pyopenapi_gen/pull/151),
+  [`9859941`](https://github.com/mindhiveoy/pyopenapi_gen/commit/985994102f5a08cd50eb78f3c9a549a675667b48))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#151](https://github.com/mindhiveoy/pyopenapi_gen/pull/151),
+  [`9859941`](https://github.com/mindhiveoy/pyopenapi_gen/commit/985994102f5a08cd50eb78f3c9a549a675667b48))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- **ci**: Prevent [skip ci] accumulation from breaking semantic-release auto-trigger
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#143](https://github.com/mindhiveoy/pyopenapi_gen/pull/143),
+  [`0ed40fb`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0ed40fbde3cc41f560539ce489d2728830412486))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#137](https://github.com/mindhiveoy/pyopenapi_gen/pull/137),
+  [`3d675c6`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3d675c645df3865abd1122ba730efb71312fa903))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cat…
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#148](https://github.com/mindhiveoy/pyopenapi_gen/pull/148),
+  [`bedcabe`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bedcabee7114c6db7da231a1942d501d6e027e76))
+
+- **core**: Resolve array item schema false positive cycle detection and optimise response
+  deserialisation ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#137](https://github.com/mindhiveoy/pyopenapi_gen/pull/137),
+  [`3d675c6`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3d675c645df3865abd1122ba730efb71312fa903))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+### Chores
+
+- Sync main (v2.0.3 release) into develop
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- Sync main (v2.0.3 release) into develop
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- Sync main (v2.0.3 release) into develop
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- Sync main (v2.0.3 release) into develop
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- Sync version 2.0.1 from main to develop
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- Sync version 2.0.1 from main to develop
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- Sync version 2.0.1 from main to develop
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- Sync version 2.0.1 from main to develop
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- Sync version 2.0.1 from main to develop
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- Sync version 2.0.1 from main to develop
+  ([#139](https://github.com/mindhiveoy/pyopenapi_gen/pull/139),
+  [`7faf179`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7faf179bf9994c32353f42a3b510a64486fb9fdb))
+
+- Sync version 2.0.1 from main to develop
+  ([#135](https://github.com/mindhiveoy/pyopenapi_gen/pull/135),
+  [`bf952a8`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bf952a84f69dd4f599180c781c3a68c94cb123f0))
+
+- Sync version 2.0.1 from main to develop
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#139](https://github.com/mindhiveoy/pyopenapi_gen/pull/139),
+  [`7faf179`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7faf179bf9994c32353f42a3b510a64486fb9fdb))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([`d86becc`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d86becc42a2ef02234e6e9582fadb1d9b5743d17))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#139](https://github.com/mindhiveoy/pyopenapi_gen/pull/139),
+  [`7faf179`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7faf179bf9994c32353f42a3b510a64486fb9fdb))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([`5379675`](https://github.com/mindhiveoy/pyopenapi_gen/commit/53796755212075e262bb98ccb6eb3b0a65bbfd4c))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **merge**: Sync develop with main to resolve conflicts
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#139](https://github.com/mindhiveoy/pyopenapi_gen/pull/139),
+  [`7faf179`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7faf179bf9994c32353f42a3b510a64486fb9fdb))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **release**: Merge develop into main for v2.1.0 release
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#139](https://github.com/mindhiveoy/pyopenapi_gen/pull/139),
+  [`7faf179`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7faf179bf9994c32353f42a3b510a64486fb9fdb))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#139](https://github.com/mindhiveoy/pyopenapi_gen/pull/139),
+  [`7faf179`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7faf179bf9994c32353f42a3b510a64486fb9fdb))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#135](https://github.com/mindhiveoy/pyopenapi_gen/pull/135),
+  [`bf952a8`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bf952a84f69dd4f599180c781c3a68c94cb123f0))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([`e03ddd0`](https://github.com/mindhiveoy/pyopenapi_gen/commit/e03ddd039aa17a710e39e2a5b3bd92a2d5a31f00))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **sync**: Sync develop with main v2.1.0
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **sync**: Sync develop with main v2.1.0
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+### Documentation
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#147](https://github.com/mindhiveoy/pyopenapi_gen/pull/147),
+  [`71e1295`](https://github.com/mindhiveoy/pyopenapi_gen/commit/71e1295900c2361d1c622ca4fe65e58ee08b3b25))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#145](https://github.com/mindhiveoy/pyopenapi_gen/pull/145),
+  [`f055f3f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f055f3fc7953f30f10793a5428b3c6cfc027288c))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#141](https://github.com/mindhiveoy/pyopenapi_gen/pull/141),
+  [`97483d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97483d4ee4122897bade0f6cd8dc64bf5039cb71))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#139](https://github.com/mindhiveoy/pyopenapi_gen/pull/139),
+  [`7faf179`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7faf179bf9994c32353f42a3b510a64486fb9fdb))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([`cd46d6b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cd46d6b3823737a3fa4e6d9b14e02565bae9bb4f))
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+- **workflow**: Add semantic-release commit naming conventions
+  ([#151](https://github.com/mindhiveoy/pyopenapi_gen/pull/151),
+  [`9859941`](https://github.com/mindhiveoy/pyopenapi_gen/commit/985994102f5a08cd50eb78f3c9a549a675667b48))
+
+### Features
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+### Performance Improvements
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#153](https://github.com/mindhiveoy/pyopenapi_gen/pull/153),
+  [`af39e47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/af39e478908e66f325c7ee418fe240f00ca8f465))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#150](https://github.com/mindhiveoy/pyopenapi_gen/pull/150),
+  [`cad4cc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cad4cc1246bc657ce9df0482cf44645a7d6fc442))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#142](https://github.com/mindhiveoy/pyopenapi_gen/pull/142),
+  [`6f5efbf`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6f5efbf03c79338db687a0b4a743c1552272f738))
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#149](https://github.com/mindhiveoy/pyopenapi_gen/pull/149),
+  [`7f5b80f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f5b80f3f795b169ccee998825c194220b0ae7f6))
+
+
+## v2.1.0 (2025-11-20)
+
+### Bug Fixes
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- **core**: Add datetime and date field handling to cattrs converter
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+### Chores
+
+- Sync main (v2.0.3 release) into develop
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- Sync version 2.0.1 from main to develop
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([`cb7832b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cb7832beb7bf81471ee10eeeacba5ad74540bfbd))
+
+- **release**: Sync version 2.0.3 from main to develop
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+### Documentation
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+### Features
+
+- **core**: Datetime/date handling and pipeline optimization
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+### Performance Improvements
+
+- **ci**: Remove redundant tests and quality checks from release pipeline
+  ([#146](https://github.com/mindhiveoy/pyopenapi_gen/pull/146),
+  [`f646324`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f64632407305b5d03964222d013f0145baf7c16e))
+
+
+## v2.0.3 (2025-11-20)
+
+### Bug Fixes
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+- **core**: Implement generic camelCase/snake_case field mapping for cattrs converter
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+- **core**: Resolve type checking and security issues in cattrs converter
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+### Chores
+
+- Sync version 2.0.1 from main to develop
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+- **merge**: Sync version 2.0.2 from main to develop
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([`5f7a70a`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5f7a70aaaf1a77d7257c6c3dd826e2bbcf1b9f98))
+
+### Documentation
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#140](https://github.com/mindhiveoy/pyopenapi_gen/pull/140),
+  [`63c0f3c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63c0f3c75831ee1c6e376d61f99ac8f45c835cb4))
+
+
+## v2.0.2 (2025-11-20)
+
+### Bug Fixes
+
+- Ensure auto-approve waits for Poetry lock fix workflow
+  ([#136](https://github.com/mindhiveoy/pyopenapi_gen/pull/136),
+  [`d9749cd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d9749cde987440bed9ebb1a4c19196d093f83111))
+
+### Chores
+
+- Sync version 2.0.1 from main to develop
+  ([#136](https://github.com/mindhiveoy/pyopenapi_gen/pull/136),
+  [`d9749cd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d9749cde987440bed9ebb1a4c19196d093f83111))
+
+- **deps**: Update poetry.lock for commitizen 4.10.0
+  ([#136](https://github.com/mindhiveoy/pyopenapi_gen/pull/136),
+  [`d9749cd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d9749cde987440bed9ebb1a4c19196d093f83111))
+
+- **deps**: Update poetry.lock for python-semantic-release 10.5.2
+  ([#136](https://github.com/mindhiveoy/pyopenapi_gen/pull/136),
+  [`d9749cd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d9749cde987440bed9ebb1a4c19196d093f83111))
+
+- **release**: Prepare v2.0.2 with dependency updates and automation improvements
+  ([#136](https://github.com/mindhiveoy/pyopenapi_gen/pull/136),
+  [`d9749cd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d9749cde987440bed9ebb1a4c19196d093f83111))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([#136](https://github.com/mindhiveoy/pyopenapi_gen/pull/136),
+  [`d9749cd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d9749cde987440bed9ebb1a4c19196d093f83111))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([`b52f18f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b52f18ff99780e59d0d2588e26318fa85d481c78))
+
+### Documentation
+
+- Add automated Poetry lock conflict resolution for Claude pipeline
+  ([#136](https://github.com/mindhiveoy/pyopenapi_gen/pull/136),
+  [`d9749cd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d9749cde987440bed9ebb1a4c19196d093f83111))
+
+
+## v2.0.1 (2025-11-20)
+
+### Bug Fixes
+
+- Remove automatic response unwrapping for schemas with "data" field
+  ([`8abe4a9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8abe4a9c798304505e0fd510a0aead99e0a989ce))
+
+### Chores
+
+- **release**: Sync __init__.py version [skip ci]
+  ([`f3e82f6`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f3e82f643979e696959d798e850330749442ad1a))
+
+### Code Style
+
+- Apply Black formatting to test files
+  ([`ce6472a`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ce6472ac827bae9dd0e4b21e68e0dd0d2fee55c0))
+
+
+## v2.0.0 (2025-11-19)
+
+### Chores
+
+- **release**: Sync __init__.py version [skip ci]
+  ([`0c5a5b5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0c5a5b5e5dc77da1687aadf02bd47e2819110162))
+
+### Refactoring
+
+- Migrate from BaseSchema to cattrs for 10x performance improvement
+  ([`f5a8cec`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f5a8cec7b830a0b4435d0b00373d33a350643384))
+
+### Breaking Changes
+
+- Generated clients no longer inherit from BaseSchema. Clients generated with previous versions will
+  continue to work, but newly generated clients use cattrs with Meta class for field mappings.
+
+
+## v1.0.0 (2025-11-19)
+
+### Bug Fixes
+
+- **codegen**: Use proper deserialisation for array type alias responses
+  ([`5be1243`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5be12436822ff702a77b1b3b34fa960131623159))
+
+### Chores
+
+- Regenerate poetry.lock
+  ([`ca4c2bc`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ca4c2bcdaa7cc53564103e7bfa5f76fe054974fc))
+
+- **release**: Sync __init__.py version [skip ci]
+  ([`8b879c8`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8b879c8542e14844aa345d5abfc1f7b36612a610))
+
 
 ## v0.23.1 (2025-11-07)
 
@@ -7,20 +2504,6 @@
 
 - **schemas**: Add automatic base64 encoding/decoding for bytes fields
   ([`b611b4c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b611b4cf37a5714b15f6cb4840b5ebfc0bbb0079))
-
-Implements OpenAPI 3.0 specification compliance for binary data handling. When schema fields have
-  type `bytes`, the BaseSchema class now automatically: - Decodes base64 strings to bytes in
-  from_dict() (API → Python) - Encodes bytes to base64 strings in to_dict() (Python → API)
-
-This fixes runtime errors where APIs return base64-encoded strings for binary fields per OpenAPI
-  standard (format: "byte"), but generated clients expected pre-decoded bytes objects.
-
-Enhanced _extract_base_type() to handle both typing.Union and types.UnionType for proper Python
-  3.10+ union syntax support (bytes | None).
-
-Comprehensive test coverage includes: - Basic encoding/decoding operations - Optional bytes fields
-  (bytes | None) - Round-trip serialization - Edge cases (empty bytes, control chars, 1MB files,
-  image headers) - Unicode content within bytes
 
 ### Chores
 
@@ -35,23 +2518,6 @@ Comprehensive test coverage includes: - Basic encoding/decoding operations - Opt
 - **security**: Implement case-insensitive Content-Type header comparison
   ([`cc3606c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cc3606cded8b3f7de4246bacc1fe832f9b5e0559))
 
-Implements RFC 7230 compliant case-insensitive Content-Type header comparison for multi-content-type
-  responses. This addresses a security consideration where malformed or non-standard case headers
-  could bypass content-type detection.
-
-Changes: - Generated code now normalizes Content-Type header to lowercase - Comparison strings are
-  also lowercase for case-insensitive matching - Added comprehensive RFC 7230 compliance comments -
-  Added test for mixed-case content-type handling
-
-Example generated code: content_type = response.headers.get("content-type",
-  "").split(";")[0].strip().lower() if content_type == "application/json": # lowercase comparison
-  return DocumentResponse.from_dict(response.json())
-
-This ensures "Application/JSON", "application/json", and "APPLICATION/JSON" are all handled
-  correctly per HTTP specification.
-
-Test coverage: 1383 tests pass, all quality gates pass
-
 ### Chores
 
 - **release**: Sync __init__.py version [skip ci]
@@ -61,21 +2527,6 @@ Test coverage: 1383 tests pass, all quality gates pass
 
 - **types**: Add multi-content-type response support with Union types
   ([`8739d3e`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8739d3e86ead2bb70761100938ff1d35d7f60c95))
-
-Add support for OpenAPI responses with multiple content types, enabling generated clients to handle
-  conditional response types based on Content-Type headers at runtime.
-
-Key changes: - ResponseStrategy now detects multiple content types and creates Union types - Added
-  content_type_mapping for runtime Content-Type header checking - Response handler generates
-  conditional code based on Content-Type - text/* content types correctly default to str instead of
-  bytes - Single content-type responses without schema infer type from content-type
-
-Generated clients now produce Union[TypeA, TypeB] return types when a response defines multiple
-  content types (e.g., application/json and application/octet-stream), with runtime Content-Type
-  header checking to return the appropriate type.
-
-Test coverage: 85% for response_strategy.py, 14 comprehensive tests added covering edge cases
-  including text/* inference, empty content, and schema resolution failures.
 
 
 ## v0.22.0 (2025-10-27)
@@ -90,283 +2541,35 @@ Test coverage: 85% for response_strategy.py, 14 comprehensive tests added coveri
 - **architecture**: Update docs for Protocol and Mock generation
   ([`8574371`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8574371565138dd4ebd59cc5822a813d152e7e26))
 
-Update architecture documentation to include Protocol and Mock generation in the pipeline. Rewrite
-  endpoint_visitor documentation with Why→What→How structure.
-
-Changes to docs/architecture.md: - Updated Core Components section to mention Protocol and Mock
-  generation - Added Protocol Generation description to Visitor System - Added MocksEmitter to
-  Emitter System - Updated architecture diagram to show Protocol and Mock generation nodes - Updated
-  Stage 2 (Visiting) to include Protocol and Mock generation steps - Removed "NEW" version markers
-  for unified type resolution
-
-Changes to docs/endpoint_visitor.md: - Complete rewrite with Why→What→How structure - Added "Why
-  This Visitor?" section explaining purpose - Documented three key outputs: Implementation,
-  Protocol, Mock - Added Core Responsibilities section with detailed subsections - Documented key
-  methods (visit_IROperation, emit_endpoint_client_class, etc.) - Added code examples for Protocol
-  and Mock generation - Included Generated Structure section showing all three outputs - Added
-  Testing Benefits section
-
-Changes to docs/README.md: - Added link to protocol_and_mock_generation.md guide - Updated Endpoint
-  Visitor description to mention Protocol and Mock support - Maintains consistent documentation
-  index
-
-Changes to CLAUDE.md: - Added Testing Support subgraph to architecture diagram - Added Testing
-  Support section under Generated Client Features - Documented Protocol definitions, Mock helpers,
-  Compile-time validation - Added protocol_and_mock_generation.md to documentation index - Removed
-  "NEW" markers from all documentation references
-
-Documentation standards applied: - Why→What→How structure throughout - Mermaid diagrams for complex
-  concepts - Progressive information architecture - Code examples with proper syntax - No version
-  history in content
-
-Consistency improvements: - All docs now mention Protocol and Mock generation where relevant -
-  Architecture documentation aligns with implementation - Component docs reference supporting
-  components correctly - Documentation index is complete and accurate
-
-Files: - docs/architecture.md (modified) - docs/endpoint_visitor.md (modified, complete rewrite) -
-  docs/README.md (modified) - CLAUDE.md (modified)
-
 - **guides**: Add comprehensive Protocol and Mock generation guide
   ([`aea11da`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aea11dac6c560100e0fc43befc97b3ef6c2069e6))
 
-Add complete documentation guide for Protocol-based testing and mock helper classes.
-
-Documentation structure (60+ sections): - Why Protocol and Mock generation exists - What gets
-  generated (Protocol, Implementation, Mocks) - How the generation pipeline works - Usage patterns
-  (Manual, Auto-Generated, Hybrid) - Dependency injection pattern examples - Compile-time validation
-  examples - Generated file structure - Implementation details and algorithms - Testing benefits -
-  Comparison with traditional mocking approaches - Advanced scenarios (stateful mocks, parametrised
-  behavior)
-
-Key sections: 1. Why Protocol and Mock Generation? - Problem: Testing requires separation of
-  business logic from HTTP - Solution: Auto-generated structural contracts and mock helpers
-
-2. What Gets Generated? - Protocol definitions with @runtime_checkable - Implementation classes
-  inheriting from Protocols - Mock helper classes with NotImplementedError stubs
-
-3. How It Works - Generation pipeline with mermaid diagrams - Protocol extraction algorithm - Mock
-  generation algorithm
-
-4. Usage Patterns - Manual Protocol implementation (full control) - Auto-generated mock helpers
-  (quick setup) - Hybrid auto-create with MockAPIClient (partial mocks)
-
-5. Dependency Injection Pattern - Business logic accepting Protocol types - Production usage with
-  real clients - Test usage with mock clients
-
-6. Compile-Time Validation - Protocol enforcement by mypy - Mock validation examples - API change
-  detection at compile time
-
-Documentation approach: - Uses Why→What→How structure consistently - Includes mermaid diagrams for
-  complex flows - Provides complete code examples - Shows comparison with traditional approaches -
-  Focuses on practical developer experience - No version history markers
-
-Technical accuracy: - All code examples are syntactically correct - Examples match generated code
-  structure - Algorithms documented match implementation - File paths and structures are accurate
-
-Files: - docs/protocol_and_mock_generation.md (new, ~500 lines)
-
 - **readme**: Update README with auto-generated mock helpers section
   ([`78225a6`](https://github.com/mindhiveoy/pyopenapi_gen/commit/78225a6b8dc16810c54da3bc9eaf4d1f042e4adf))
-
-Update README with Auto-Generated Mock Helper Classes section documenting the mocks/ directory
-  structure and usage patterns.
-
-Content added: - Auto-Generated Mock Helper Classes section (after Protocol-Based Design) -
-  Generated mocks/ directory structure diagram - Quick start examples for using mock helpers -
-  Hybrid auto-create pattern with MockAPIClient - NotImplementedError guidance message examples -
-  Comparison: Manual Protocol vs Auto-Generated mocks - When to use each approach
-
-Documentation structure: 1. Generated Mocks Structure - Package layout with mocks/ and endpoints/
-  subdirectories
-
-2. Quick Start with Auto-Generated Mocks - Inherit from MockXClient, override specific methods - Use
-  MockAPIClient with hybrid auto-create
-
-3. Hybrid Auto-Create Pattern - Partial mock injection - Auto-creation for unimplemented endpoints
-
-4. NotImplementedError Guidance - Example error messages with override instructions
-
-5. Comparison Section - Manual Protocol implementation (full control) - Auto-generated helpers (less
-  boilerplate) - When to use each approach
-
-Content placement: - Added after "Real-World Testing Example" (line ~870) - Before "Known
-  Limitations" section - Maintains logical flow from Protocol basics to mock helpers
-
-Documentation cleanup: - Removed "New in v0.22+" version marker - Focus on what exists, not when it
-  was added - Follows "no history in guides" principle
-
-Files: - README.md (modified, ~130 lines added)
 
 ### Features
 
 - **emitters**: Add MocksEmitter for generating mocks/ package structure
   ([`824d377`](https://github.com/mindhiveoy/pyopenapi_gen/commit/824d377233d01b0d42af1f803d773785e5f1dc38))
 
-Implement MocksEmitter to generate complete mocks/ directory structure with MockAPIClient and
-  tag-based mock classes.
-
-Implementation details: - Add mocks_emitter.py with MocksEmitter class - Generate mocks/ package
-  with endpoints/ subdirectory - Create MockAPIClient with hybrid auto-create pattern - Generate
-  mock_{tag}.py files for each endpoint client - Create __init__.py files with proper exports -
-  Integrate with ClientGenerator orchestration
-
-Package structure generated: ``` mocks/ ├── __init__.py # Exports MockAPIClient and all mocks ├──
-  mock_client.py # MockAPIClient with auto-create └── endpoints/ ├── __init__.py # Exports all
-  MockXClient classes ├── mock_users.py # MockUsersClient └── mock_orders.py # MockOrdersClient ```
-
-Hybrid auto-create pattern: - MockAPIClient accepts optional endpoint client overrides -
-  Auto-creates mock instances for non-overridden endpoints - Allows partial mock injection for
-  targeted testing - Provides clear NotImplementedError when unimplemented methods are called
-
-Integration changes: - Update endpoints_emitter.py to call generate_endpoint_protocol() - Modify
-  client_generator.py to orchestrate mocks generation - Ensure Protocol generation happens before
-  implementation generation - Add mocks/ to generated client package structure
-
-Benefits: - Complete mocks/ package ready to use immediately after generation - Hybrid pattern
-  allows testing with minimal mock implementation - Clear separation between Protocol contracts and
-  mock helpers - Maintains consistency with endpoints/ structure
-
-Files: - src/pyopenapi_gen/emitters/mocks_emitter.py (new) -
-  src/pyopenapi_gen/emitters/endpoints_emitter.py (modified) -
-  src/pyopenapi_gen/generator/client_generator.py (modified)
-
 - **endpoints**: Add mock helper class generation with NotImplementedError stubs
   ([`63bbf51`](https://github.com/mindhiveoy/pyopenapi_gen/commit/63bbf51c38d3994aa3233b06237c05f71950a58b))
 
-Implement mock helper class generation to create base classes for testing with helpful error
-  messages.
-
-Implementation details: - Add mock_generator.py with MockGenerator class - Implement
-  generate_endpoint_mock_class() in EndpointVisitor - Generate NotImplementedError stubs for all
-  operation methods - Create helpful error messages with override examples - Add
-  generate_client_mock_class() in ClientVisitor for main client mock - Maintain signature
-  compatibility with Protocol contracts
-
-Technical approach: - Reuse EndpointMethodGenerator signature extraction - Generate method stubs
-  with NotImplementedError and guidance messages - Include code examples in error messages showing
-  how to override - Ensure mock classes can be used as base classes for test inheritance - Support
-  both endpoint client mocks and main API client mock
-
-Error message format: ```python raise NotImplementedError( "MockUsersClient.get_user() not
-  implemented.\n" "Override this method in your test:\n" " class
-  TestUsersClient(MockUsersClient):\n" " async def get_user(self, user_id: int) -> User:\n" " return
-  User(...)" ) ```
-
-Benefits: - Reduces boilerplate in test code - Provides clear guidance when methods are called but
-  not implemented - Enables selective method override pattern - Maintains type compatibility with
-  Protocols
-
-Files: - src/pyopenapi_gen/visit/endpoint/generators/mock_generator.py (new) -
-  src/pyopenapi_gen/visit/endpoint/endpoint_visitor.py (modified) -
-  src/pyopenapi_gen/visit/client_visitor.py (modified)
-
 - **endpoints**: Add Protocol generation for endpoint structural typing
   ([`1bf42d8`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1bf42d84b063647aa2460b2b337601b0fb2d7d46))
-
-Implement Protocol generation infrastructure to create @runtime_checkable Protocol classes for all
-  endpoint clients.
-
-Implementation details: - Add protocol_helpers.py with ProtocolGenerator class - Implement
-  generate_endpoint_protocol() in EndpointVisitor - Extract method signatures from generated
-  implementation code - Handle @overload decorated methods with proper stub conversion - Convert
-  AsyncIterator methods to def signatures per PEP 544 - Add Protocol import management in
-  RenderContext
-
-Technical approach: - Parse generated method code line-by-line to extract signatures - Detect
-  signature boundaries and multi-line parameter lists - Convert implementation signatures to
-  Protocol stubs (: → : ...) - Ensure Protocol classes use @runtime_checkable decorator - Generate
-  comprehensive Protocol docstrings
-
-Benefits: - Enables structural typing and dependency injection - Provides compile-time validation
-  with mypy - Allows mock implementations to be type-checked against Protocol contracts - Zero
-  runtime overhead (Protocols are type-checking only)
-
-Files: - src/pyopenapi_gen/visit/protocol_helpers.py (new) -
-  src/pyopenapi_gen/visit/endpoint/endpoint_visitor.py (modified)
 
 ### Refactoring
 
 - **visit**: Remove unused protocol_helpers module
   ([`2389fc9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/2389fc9301461a754d169bc5c971dc833ee2a305))
 
-Remove protocol_helpers.py which was never imported or used:
-
-Technical changes: - Deleted src/pyopenapi_gen/visit/protocol_helpers.py (110 lines) - Removed
-  unused import from client_visitor.py - Removed unused import from endpoint_visitor.py - Removed
-  unused self.protocol_generator instantiation in both visitors
-
-Analysis showed: - Module had 20% test coverage only because it was never imported -
-  ProtocolGenerator class was never instantiated or used - Protocol generation is now handled
-  directly in EndpointVisitor.generate_endpoint_protocol() - All 1368 tests pass after removal,
-  confirming code was truly unused
-
-Impact: - Zero functional impact (code was never executed) - Cleaner codebase with no dead code -
-  Improved endpoint_visitor.py coverage from 99% to 100%
-
 ### Testing
 
 - **endpoints**: Add comprehensive Protocol and Mock generation tests
   ([`2da2cfb`](https://github.com/mindhiveoy/pyopenapi_gen/commit/2da2cfbd1d3a47d11a0525e8d8972403588c2ac4))
 
-Add 8 real contract tests validating Protocol and Mock generation without mock theatre:
-
-Test implementation: - tests/visit/endpoint/test_protocol_mock_generation.py created - Uses real
-  IROperation, IRParameter, IRRequestBody, IRResponse, IRSchema objects - No mocking of internal
-  components (EndpointMethodGenerator, CodeWriter) - Validates actual generated code structure and
-  content
-
-Test coverage: - TestProtocolGeneration: 3 tests for Protocol class generation - Single operation
-  with @runtime_checkable decorator - Multiple operations handling - Import registration validation
-  - TestMockGeneration: 3 tests for Mock class generation - NotImplementedError stub generation -
-  Multiple operations stub handling - Helpful docstring and override guidance -
-  TestProtocolAndImplementationIntegration: 2 integration tests - Complete Protocol + Implementation
-  generation - Proper __init__ with transport and base_url
-
-Quality improvements: - Eliminates mock theatre from test suite - Provides real behavioral
-  validation - Clear "Scenario" and "Expected Outcome" documentation - All tests use real objects,
-  no mocks
-
-Test results: - All 8 new tests passing - Total test count: 1368/1368 passing - Coverage maintained
-  at 89% (above 85% requirement) - endpoint_visitor.py now at 100% coverage
-
 - **generation**: Add comprehensive tests for Protocol and Mock generation
   ([`89dbb20`](https://github.com/mindhiveoy/pyopenapi_gen/commit/89dbb205ac476510db1e894fa06887c1e71f9ec2))
-
-Add comprehensive test coverage for Protocol generation, mock helper generation, and integration
-  with the generation pipeline.
-
-Test coverage added: - Protocol generation from endpoint operations - Mock helper class generation
-  with NotImplementedError stubs - MocksEmitter package structure generation - Integration with
-  EndpointsEmitter - @overload method handling in Protocols - AsyncIterator conversion (async def →
-  def) - Error message formatting and content
-
-Test files modified: - tests/visit/endpoint/test_endpoint_visitor.py -
-  test_generate_endpoint_protocol__creates_protocol_class() -
-  test_generate_endpoint_protocol__handles_overload_methods() -
-  test_generate_endpoint_mock_class__creates_mock_with_stubs()
-
-- tests/visit/test_client_visitor.py -
-  test_generate_client_mock_class__creates_mock_with_auto_create()
-
-- tests/emitters/test_endpoints_emitter.py - test_emit__generates_protocols_with_implementations()
-
-- tests/generation_issues/test_overload_naming_issues.py - Updated to handle Protocol generation in
-  output
-
-Testing approach: - Use IROperation fixtures to test generation - Verify generated code structure
-  and content - Check Protocol stub format (: ...) - Validate error message content and formatting -
-  Ensure type annotations are preserved - Test integration across emitter pipeline
-
-Coverage maintained: - All new code paths covered - Edge cases tested (overload, AsyncIterator,
-  multi-line signatures) - Integration tests verify end-to-end generation - Maintains project's ≥85%
-  coverage requirement
-
-Quality verification: - All 1360 tests passing - No type checking errors (mypy strict mode) - No
-  linting violations (ruff) - Proper formatting (black)
-
-Files: - tests/visit/endpoint/test_endpoint_visitor.py (modified) -
-  tests/visit/test_client_visitor.py (modified) - tests/emitters/test_endpoints_emitter.py
-  (modified) - tests/generation_issues/test_overload_naming_issues.py (modified)
 
 
 ## v0.21.1 (2025-10-24)
@@ -375,35 +2578,6 @@ Files: - tests/visit/endpoint/test_endpoint_visitor.py (modified) -
 
 - **codegen**: Fix enum parameter serialization in query, header, and path parameters
   ([`be5391f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/be5391ff9fde14a1826aa217c077b06a0f832f8c))
-
-Implement consistent parameter serialization using DataclassSerializer.serialize() for query,
-  header, and path parameters to handle enum-to-string conversion correctly.
-
-Technical changes: - _write_query_params() now wraps all parameter values in
-  DataclassSerializer.serialize() - _write_header_params() now wraps all parameter values in
-  DataclassSerializer.serialize() - generate_url_and_args() serializes path params before f-string
-  interpolation - Added context.add_import() calls to ensure DataclassSerializer is imported in
-  generated code
-
-Implementation approach: Query/header parameters use DataclassSerializer.serialize() in dict
-  construction: Required: "{param}": DataclassSerializer.serialize(param_var)
-
-Optional: **{{"{param}": DataclassSerializer.serialize(param_var)} if param_var is not None else {}}
-
-Path parameters are serialized before URL construction to prevent enum objects in f-strings (would
-  produce "EnumType.VALUE" instead of "value"): param_var = DataclassSerializer.serialize(param_var)
-
-Breaking changes: None API changes: None (generated code behavior corrected to match intended
-  design)
-
-Test coverage: - 5 new TDD tests validate enum serialization for all parameter types - All 1360
-  tests passing with 88.43% coverage - Integration tests confirm correct mypy validation and runtime
-  behavior
-
-Fixes issue where enum parameters (e.g., DocumentStatus.INDEXED) were passed directly to httpx
-  instead of being converted to their string values ("indexed"), causing incorrect API calls.
-
-Related: business_swagger.json list_documents endpoint with status parameter
 
 ### Chores
 
@@ -418,28 +2592,6 @@ Related: business_swagger.json list_documents endpoint with status parameter
 - **serialization**: Respect BaseSchema field mappings in DataclassSerializer
   ([`ef5d365`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ef5d3656008417bbae17e6370e33e7b0c12cefd6))
 
-BREAKING CHANGE: DataclassSerializer now correctly maps Python snake_case field names to API
-  camelCase field names when serializing BaseSchema instances.
-
-Problem: DataclassSerializer.serialize() was using Python field names (snake_case) directly as
-  dictionary keys, ignoring the field name mappings defined in
-  BaseSchema.Meta.key_transform_with_load. This caused API requests to send incorrect field names,
-  breaking communication with camelCase APIs.
-
-Solution: Modified DataclassSerializer._serialize_with_tracking() to detect BaseSchema instances and
-  use their to_dict() method, which properly handles field name mapping. Falls back to original
-  behavior for plain dataclasses to maintain backwards compatibility.
-
-Changes: - Updated DataclassSerializer._serialize_with_tracking() in core/utils.py - Added 5
-  comprehensive unit tests for field mapping scenarios - Added 2 end-to-end integration tests with
-  business_swagger.json - All existing tests pass with 88.42% coverage (exceeds 85% requirement)
-
-Example: Before: {"data_source_id": "123"} ❌
-
-After: {"dataSourceId": "123"} ✅
-
-Fixes critical bug affecting all generated clients with camelCase APIs.
-
 ### Chores
 
 - **release**: Sync __init__.py version [skip ci]
@@ -447,7 +2599,7 @@ Fixes critical bug affecting all generated clients with camelCase APIs.
 
 ### Breaking Changes
 
-- **serialization**: Dataclassserializer now correctly maps Python snake_case field names to API
+- **serialization**: DataclassSerializer now correctly maps Python snake_case field names to API
   camelCase field names when serializing BaseSchema instances.
 
 
@@ -457,40 +2609,6 @@ Fixes critical bug affecting all generated clients with camelCase APIs.
 
 - **codegen**: Resolve method naming and file handling in overloaded endpoints
   ([`190e581`](https://github.com/mindhiveoy/pyopenapi_gen/commit/190e5819e99edf37d14722b075069851d03c4c3b))
-
-This commit fixes two critical issues in code generation for operations with multiple content types
-  (overloaded methods):
-
-1. **Method Naming**: Overloaded methods were using camelCase from OpenAPI operationId instead of
-  converting to Python's snake_case convention. - Fixed: Added NameSanitizer.sanitize_method_name()
-  in overload_generator.py - Example: updateDocument -> update_document
-
-2. **File Upload Handling**: Multipart/form-data file uploads were incorrectly being passed through
-  DataclassSerializer.serialize(), which is designed for dataclass-to-dict conversion, not file I/O.
-  - Fixed: Pass file dict directly to httpx transport in endpoint_method_generator.py - Rationale:
-  httpx expects raw IO objects, not serialized data
-
-Both issues only affected operations with multiple content types (JSON + multipart). Standard
-  single-content-type operations were unaffected.
-
-Changes: - src/pyopenapi_gen/visit/endpoint/generators/overload_generator.py: Added NameSanitizer
-  import and method name sanitisation in two locations (overload signatures and implementation
-  signatures)
-
-- src/pyopenapi_gen/visit/endpoint/generators/endpoint_method_generator.py: Removed
-  DataclassSerializer.serialize() for file parameters in multipart handling, passing files directly
-  to transport
-
-- tests/visit/endpoint/generators/test_overload_generator.py: Added unit tests for snake_case
-  conversion in overload and implementation signatures
-
-- tests/visit/endpoint/generators/test_endpoint_method_generator.py: Added test for file handling
-  without serialisation
-
-- tests/generation_issues/test_overload_naming_issues.py: Added integration tests verifying both
-  fixes in full code generation pipeline
-
-All tests pass (1348 tests) with full quality checks (format, lint, typecheck, security).
 
 ### Chores
 
@@ -537,23 +2655,8 @@ All tests pass (1348 tests) with full quality checks (format, lint, typecheck, s
 - **ci**: Add github_token to Claude Code action
   ([`e3a18d5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/e3a18d5377c206c9735981c588999decdf361fdf))
 
-Fixes workflow validation error when Claude workflow differs between branches. The action requires
-  either: 1. Identical workflow file on main branch, OR 2. Explicit github_token parameter
-
-Adding github_token allows the action to work on PR branches with workflow modifications before
-  they're merged to main.
-
 - **ci**: Allow dependabot in semantic-release and optimize Claude Code reviews
   ([`717e90c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/717e90c3a8bff13757434fb1375b0b7a30968fd9))
-
-1. Added dependabot and renovate to semantic-release allowed_bots list - Fixes: Workflow initiated
-  by non-human actor error - Allows automated dependency updates to trigger releases
-
-2. Updated Claude Code workflow prompt to skip quality gates - CI pipeline already runs: Black,
-  Ruff, mypy, Bandit, pytest - Claude now focuses on: code logic, security, architecture - Avoids
-  duplicate work and speeds up reviews
-
-These changes reduce CI time and eliminate redundant quality checks.
 
 ### Chores
 
@@ -568,53 +2671,16 @@ These changes reduce CI time and eliminate redundant quality checks.
 - **readme**: Add comprehensive programmatic API documentation
   ([`d2fca57`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d2fca57f62b0a1c5f718401df3c1b8ac7a7bb02b))
 
-Added detailed documentation for using pyopenapi_gen as a Python library:
-
-- Why programmatic usage section - Architecture diagram with mermaid - Basic usage examples -
-  Advanced usage with all options - Multi-client generation script - Build system integration
-  example - Complete API reference - Comparison: CLI vs programmatic usage
-
-This documentation covers the generate_client() function, ClientGenerator class, and GenerationError
-  exception, making it easy for users to integrate the generator into their build systems, CI/CD
-  pipelines, and custom tooling.
-
 ### Features
 
 - **codegen**: Add @overload support for multi-content-type operations
   ([`bf608a7`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bf608a7c47dc4c528f407456478002e3d6779886))
 
-Implement PEP 484 @overload signatures for operations accepting multiple content types
-  (application/json, multipart/form-data, etc.). Enables IDE autocomplete and type checking for
-  endpoints with varying request formats.
-
-Technical approach: - OverloadMethodGenerator creates @overload decorators per content type -
-  Literal types constrain content_type parameter per overload - Type-safe parameter mapping:
-  JSON→body, multipart→files, form→data - Assert statements for mypy type narrowing (validated,
-  marked nosec B101)
-
-This addresses developer experience issues when working with upload endpoints that accept both JSON
-  metadata and multipart file uploads.
-
 - **codegen**: Integrate @overload generation into endpoint method generator
   ([`d29cd13`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d29cd131ed498c389366712eb873430ec0eb7e37))
 
-Refactor EndpointMethodGenerator to detect multi-content-type operations and delegate to
-  OverloadMethodGenerator for type-safe signature generation. Maintains full backward compatibility
-  for single-content-type operations.
-
-Implementation: - generate() branches on has_multiple_content_types() check -
-  _generate_standard_method() preserves existing single-content-type logic -
-  _generate_overloaded_method() orchestrates overload generation + runtime dispatch - Runtime
-  dispatch validates exactly one content-type parameter provided
-
-Developers now receive accurate IDE autocomplete for multi-format endpoints, eliminating guesswork
-  about which parameters are valid for each content type.
-
 - **spec**: Update business_swagger.json with multi-content-type example
   ([`5007e77`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5007e7752440856f7111a7422af09ca6da8a5a5a))
-
-- Update listDocuments endpoint with cursor and page-based pagination - Provides real-world example
-  for content-type overloading implementation
 
 
 ## v0.17.0 (2025-10-13)
@@ -629,19 +2695,6 @@ Developers now receive accurate IDE autocomplete for multi-format endpoints, eli
 - **ci**: Optimize Claude Code workflow and enable bot releases
   ([`c2efbfa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c2efbfa17f29ab040412935cf758c6c92cb1569a))
 
-1. Claude Code Workflow Optimization: - Instruct Claude to skip quality gates (formatting, linting,
-  tests, type checking) - CI pipeline already handles: Black, Ruff, mypy, Bandit, pytest - Focus
-  Claude on: code logic, security, architecture, API compatibility - Reduces duplicate work and
-  speeds up PR reviews
-
-2. Semantic-Release Bot Support: - Added allowed_bots = ["dependabot", "renovate"] to pyproject.toml
-  - Fixes: "Workflow initiated by non-human actor" error - Enables automated dependency updates to
-  trigger releases
-
-Benefits: - Faster CI reviews (Claude skips redundant checks) - Better focus (Claude concentrates on
-  logic and security) - Automated releases from bot PRs (dependabot, renovate) - Less noise in PR
-  reviews
-
 
 ## v0.16.1 (2025-10-13)
 
@@ -650,31 +2703,8 @@ Benefits: - Faster CI reviews (Claude skips redundant checks) - Better focus (Cl
 - **version**: Manually sync __init__.py to 0.16.0 after failed workflow
   ([`7ee9090`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7ee90902add14d93d471418b56514a8bcafd81cb))
 
-The semantic-release workflow successfully created version 0.16.0 but failed when trying to push the
-  __init__.py sync due to the force-with-lease issue.
-
-This commit manually syncs __init__.py to 0.16.0 to match pyproject.toml. Future releases will use
-  the new workflow logic with follow-up commits.
-
 - **workflow**: Use follow-up commit instead of amending for version sync
   ([`96f2014`](https://github.com/mindhiveoy/pyopenapi_gen/commit/96f2014bb10ecbfbe3873db32ea6a5f8334542a2))
-
-ISSUE: The git push --force-with-lease was failing with "stale info" because: 1. semantic-release
-  creates and pushes a commit 2. Our sync script tried to amend that commit 3. force-with-lease
-  detected remote had changed and rejected the push
-
-SOLUTION: Changed strategy to use a follow-up commit instead of amending: 1. Fetch latest from
-  origin/main after semantic-release pushes 2. Reset --hard to origin/main to sync local state 3.
-  Run sync script to update __init__.py 4. If changed, create a NEW commit with [skip ci] flag 5.
-  Push normally (no force needed)
-
-Benefits: - Safer: No force-pushing required - Cleaner: Normal git flow with proper commit sequence
-  - Prevents loops: [skip ci] prevents triggering another workflow run
-
-This will result in two commits per release (semantic-release + sync) but is more reliable than
-  force-pushing.
-
-Fixes: https://github.com/mindhiveoy/pyopenapi_gen/actions/runs/18461834318
 
 
 ## v0.16.0 (2025-10-13)
@@ -683,14 +2713,6 @@ Fixes: https://github.com/mindhiveoy/pyopenapi_gen/actions/runs/18461834318
 
 - **api**: Improve type annotation for generate_client return type
   ([`f35d99c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f35d99c1d2233a20fdd1a69ef0a175ab902513c4))
-
-- Change return type from List[Any] to List[Path] for better type safety - Add proper pathlib.Path
-  import to support the type annotation - Enhances IDE support and type checking for programmatic
-  API users
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-authored-by: Ville Venäläinen <undefined@users.noreply.github.com>
 
 - **api**: Update business_swagger.json descriptions and schemas
   ([`6496144`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6496144200fb8dfb28275f0d111138107775fa29))
@@ -701,63 +2723,16 @@ Co-authored-by: Ville Venäläinen <undefined@users.noreply.github.com>
 - **release**: Sync __init__.py version automatically in semantic-release workflow
   ([`7f28674`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7f2867449be1b75b2fc4b7c04073fcad3320e865))
 
-ISSUE: Semantic-release was updating pyproject.toml version but leaving __init__.py at the old
-  version, causing the version validation to fail.
-
-SOLUTION: 1. Fixed immediate issue: Updated __init__.py to match pyproject.toml (0.15.0) 2. Added
-  automatic sync: Created scripts/sync_version_to_init.py to sync version from pyproject.toml to
-  __init__.py 3. Updated workflow: Added step after semantic-release version bump that runs the sync
-  script and amends the commit if __init__.py was updated
-
-This ensures all version files stay synchronized after every semantic-release run.
-
-Fixes: https://github.com/mindhiveoy/pyopenapi_gen/actions/runs/18461374998
-
 - **security**: Address Bandit security warnings with proper logging and nosec annotations
   ([`f9b0ff3`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f9b0ff3e73ebeaaed49fc631429835ee6e99a33c))
 
-Fixed all Bandit security warnings: - Replace try-except-pass with proper exception logging in
-  parser.py - Replace try-except-pass with logging in telemetry.py - Add nosec B603 annotations to
-  all subprocess.run() calls with explanations - Add nosec B404 annotation to subprocess import with
-  justification
-
-Changes: - parser.py: Log exceptions instead of silent pass for debugging - telemetry.py: Log
-  telemetry failures for debugging - postprocess_manager.py: Document all subprocess calls are safe
-  (hardcoded commands, no shell)
-
-Bandit now reports zero issues (8 properly suppressed with nosec). All quality checks pass.
-
 - **types**: Add binary format mapping to unified type resolver
   ([`ecba081`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ecba081b37a217277ea61d58b30d1f0a7ac2e04d))
-
-- Add 'binary' to format_mapping in OpenAPISchemaResolver._resolve_string() - Ensures string schemas
-  with format=binary resolve to bytes type - Adds comprehensive test coverage for binary format
-  resolution - Closes gap between legacy and unified type systems
-
-Before: string fields with format=binary were typed as str
-
-After: string fields with format=binary are correctly typed as bytes
 
 ### Features
 
 - **api**: Add developer-friendly programmatic API with generate_client()
   ([`ec8ad0c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ec8ad0c7b166e9cb523a91d97f8639f050d940c3))
-
-Add a clean, function-based API for programmatic usage alongside the existing CLI.
-
-Key additions: - generate_client() convenience function for simple library usage - Export
-  ClientGenerator and GenerationError at package level - Comprehensive documentation with examples
-  in CLAUDE.md - Full test coverage with 9 new tests in tests/api/
-
-Benefits: - Simple one-function API: generate_client(spec_path, project_root, output_package) - No
-  need to import from deep paths or understand internal structure - Proper error handling with
-  exported GenerationError exception - Fully backward compatible - all existing code continues to
-  work - Matches patterns from similar tools (openapi-python-client, datamodel-code-generator)
-
-Documentation includes: - Basic usage examples - Advanced usage with error handling - Multi-client
-  generation scripts - Build system integration examples - Complete API reference
-
-All tests pass (9 new + existing), type-safe (mypy strict), and quality checks pass.
 
 ### Refactoring
 
@@ -772,39 +2747,8 @@ All tests pass (9 new + existing), type-safe (mypy strict), and quality checks p
 - **release**: Correct semantic-release configuration and sync version to 0.14.3
   ([`cfa0813`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cfa081393657acfaa0a1c6a29243746748872b28))
 
-Problem: - semantic-release v9 was configured with deprecated `version_pattern` syntax - This caused
-  __init__.py to not be automatically updated during releases - Version validation failed in CI
-  because __init__.py (0.10.2) != pyproject.toml (0.14.3)
-
-Solution: - Updated semantic-release config to use `version_variables` (v9+ syntax) - Synced
-  __init__.py version to 0.14.3 to match pyproject.toml - Now semantic-release will automatically
-  update all version locations
-
-Changes: - pyproject.toml: Changed version_pattern → version_variables -
-  src/pyopenapi_gen/__init__.py: Updated __version__ from 0.10.2 → 0.14.3
-
-This ensures future releases automatically sync all version files.
-
 - **types**: Correct self-import detection to avoid false positives with similar filenames
   ([`cfee36e`](https://github.com/mindhiveoy/pyopenapi_gen/commit/cfee36e4c8c57d84c0c1d967a7936c5daddf2197))
-
-Problem: - Self-import check used .endswith() for filename comparison - This caused false positives
-  when one filename was a suffix of another - Example:
-  "vector_index_with_embedding_response_data.py".endswith("embedding_response_data.py") == True -
-  Result: Missing imports for forward referenced types, causing NameError at runtime
-
-Solution: - Changed to exact basename comparison using os.path.basename() - Only files with
-  identical basenames are treated as self-imports - Added comprehensive regression tests covering: -
-  Similar module names (not self-imports) - Actual self-references (forward refs without imports) -
-  Exact filename matching requirements
-
-Changes: - src/pyopenapi_gen/types/resolvers/schema_resolver.py: Fixed self-import detection logic -
-  tests/types/test_missing_imports_bug.py: Added 3 regression tests -
-  tests/visit/test_model_visitor.py: Updated test expectations for correct import behavior -
-  .gitignore: Added patterns to ignore bug report and analysis documents
-
-Testing: - All 1309 tests pass - Verified with real business_swagger.json that previously failed -
-  Generated code now includes correct imports for cross-module references
 
 ### Features
 
@@ -819,31 +2763,6 @@ Testing: - All 1309 tests pass - Verified with real business_swagger.json that p
 - **core**: Resolve ImportError for sibling core packages in shared mode
   ([`5f76cac`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5f76caca6f13ef786e8920fb52dca9e1d02f5dbe))
 
-Fix ImportError when generating clients with shared core packages by using absolute imports instead
-  of relative imports for root-level sibling packages.
-
-Root cause: Python doesn't support relative imports beyond top-level packages. When core/ and
-  businessapi/ are siblings at root, "from ..core" fails because there's no parent package to
-  traverse.
-
-Implementation: - Modified RenderContext.add_import() to use absolute imports for core packages -
-  Added get_core_import_path() helper for import path calculation - Updated dataclass_generator.py
-  and python_construct_renderer.py - Core imports now use: "from core.schemas import BaseSchema" -
-  Previous broken format: "from ..core.schemas import BaseSchema"
-
-Testing: - Added comprehensive test suite with 7 scenarios for import path calculation - Updated
-  existing test assertions to expect absolute import format - All 1306 tests passing with 88.18%
-  coverage - Verified with business_swagger.json (1127 schemas, 117 operations) - Import validation:
-  PYTHONPATH=/path/to/output python -c "from businessapi.client import APIClient"
-
-Files modified: - src/pyopenapi_gen/context/render_context.py -
-  src/pyopenapi_gen/core/writers/python_construct_renderer.py -
-  src/pyopenapi_gen/visit/model/dataclass_generator.py -
-  tests/core/writers/test_python_construct_renderer_json_wizard.py -
-  tests/visit/model/test_dataclass_generator_json_wizard.py - tests/visit/test_model_visitor.py
-
-Files added: - tests/context/test_core_import_path.py
-
 ### Chores
 
 - **deps**: Update dependencies in poetry.lock
@@ -857,21 +2776,6 @@ Files added: - tests/context/test_core_import_path.py
 - **endpoints**: Prevent _2_2 suffix accumulation in multi-tag operations
   ([`89e500f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/89e500f9c9963492454bc3177fabf872052baac5))
 
-Operations with multiple tags previously accumulated duplicate suffixes (_2_2, _2_2_2) because the
-  same IROperation object was modified multiple times during per-tag deduplication.
-
-**Root Cause:** When an operation has multiple tags (e.g., ["Users", "Admin", "Internal"]), the SAME
-  IROperation object reference was added to multiple tag group lists. The per-tag deduplication
-  modified the same object repeatedly, causing suffix accumulation.
-
-**Solution:** - Implement global deduplication BEFORE tag grouping - New method:
-  _deduplicate_operation_ids_globally() - Called once before tag splitting - Ensures each operation
-  is renamed at most once - Removed per-tag deduplication call
-
-**Testing:** - Existing test for single-tag duplicates still passes - New test verifies multi-tag
-  operations get consistent naming - Reproduction test confirms fix resolves _2_2 accumulation - All
-  1299 tests pass with 88.16% coverage
-
 
 ## v0.14.1 (2025-10-10)
 
@@ -883,50 +2787,8 @@ Operations with multiple tags previously accumulated duplicate suffixes (_2_2, _
 - **helpers**: Modernize TypeCleaner for Python 3.9+ type syntax and union preservation
   ([`856fc33`](https://github.com/mindhiveoy/pyopenapi_gen/commit/856fc330752fa1046aac0fb028376329569d8b99))
 
-Extended TypeCleaner to handle modern Python type syntax patterns:
-
-1. Dict/dict case sensitivity (Lines 69, 261-296): - Added "or container == 'dict'" to container
-  type detection - Updated _clean_dict_type() to handle both Dict[] and dict[] - Always outputs
-  lowercase dict[] per Python 3.9+ conventions - Preserves backward compatibility during transition
-  period
-
-2. Modern union syntax preservation (Lines 45-51): - Added early handling for " | " to prevent type
-  truncation - Detects top-level unions before container parsing - Splits by pipe, cleans parts
-  independently, rejoins with union operator - Prevents "List[X] | None" being treated as malformed
-  List type
-
-3. Optional to modern union conversion: - Updated special cases to convert Optional[X] to X | None
-  format - Removed Optional from imports (no longer needed) - Modernizes type annotations throughout
-  cleaned output
-
-Bug fixes resolved: - 36 syntax errors from union truncation: "List[X] | None" → "List[X] | Non]" -
-  Case sensitivity failures after Ruff auto-formatting Dict → dict - Inconsistent type syntax in
-  generated code
-
-Impact: Fixes business_swagger.json client generation errors
-
-Quality gates: All 1278 tests passing, zero regressions
-
 - **parsing**: Add type annotation for additionalProperties field to resolve mypy error
   ([`6d4244a`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6d4244a00a35d375c666510ec61754c1d36774e8))
-
-Define explicit type for additional_properties_value parameter in _parse_schema(): - Type
-  annotation: bool | IRSchema | None - Resolves mypy strict mode error on line 566 - Supports three
-  OpenAPI additionalProperties patterns: * bool: true/false for allowing/disallowing additional
-  properties * IRSchema: schema object defining additional property validation * None:
-  additionalProperties not specified in OpenAPI spec
-
-Technical context: - mypy --strict requires explicit types for union type assignments - Field can
-  receive different types based on OpenAPI specification structure - Conditional assignment at line
-  573 assigns bool, dict-parsed IRSchema, or None - No functional changes, only type safety
-  improvement for static analysis
-
-Resolves: mypy error "Incompatible types in assignment (expression has type...)"
-
-### Chores
-
-- Merge latest changes from main
-  ([`44487cc`](https://github.com/mindhiveoy/pyopenapi_gen/commit/44487cce571920b5e2c34814c38cbab67b956097))
 
 ### Code Style
 
@@ -936,21 +2798,6 @@ Resolves: mypy error "Incompatible types in assignment (expression has type...)"
 - **format**: Apply Ruff auto-formatting to entire codebase
   ([`3b0ab6b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3b0ab6bcabe4caeee33a0e09f83bf28f58bfde76))
 
-Applied Ruff formatting to 116 files for code style consistency: - Executed: make quality-fix (Ruff
-  format + lint --fix) - Changes: Import sorting, line breaks, whitespace normalization - No
-  functional changes, only formatting adjustments
-
-Files affected: - src/pyopenapi_gen/: 72 files (core, helpers, types, visit, emitters) - tests/: 44
-  files (all test modules) - input/business_swagger.json: Reformatted JSON structure
-
-Formatting changes: - Import statement ordering per PEP 8 - Line length normalization (120 char
-  limit) - Trailing whitespace removal - Consistent indentation and spacing
-
-Quality gates: ✅ make format-check: PASSED ✅ make lint: PASSED ✅ make typecheck: PASSED ✅ make test:
-  1278 passed, 88.48% coverage
-
-No functional changes, zero test regressions
-
 - **lint**: Remove unused TypeFinalizer import from alias_generator
   ([`7b27e7c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7b27e7c5306c252bd816661e6815395ec431f2ce))
 
@@ -959,112 +2806,13 @@ No functional changes, zero test regressions
 - **types**: Enforce modern Python 3.10+ type syntax across unified type system
   ([`f642a67`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f642a679760d84aa7f3c3fdbefd856056b8a02bd))
 
-Eliminate legacy Optional[X] syntax in favour of modern X | None throughout the unified type
-  resolution pipeline, establishing architectural guarantees with three-layer protection against
-  Optional[X] leaks.
-
-Technical changes:
-
-1. UnifiedTypeService (_format_resolved_type): - Added SANITY CHECK raising ValueError for
-  Optional[X] production - Reordered formatting: quote forward refs BEFORE adding | None - Modern
-  syntax: "DataSource" | None (not "DataSource | None") - Architecture guarantee: ONLY X | None
-  syntax, NEVER Optional[X]
-
-2. TypeFinalizer (_wrap_with_optional_if_needed): - Added SANITY CHECK with error logging for
-  Optional[X] reception - Removed all Optional import statements (not needed in Python 3.10+) -
-  Fixed operation order: clean BEFORE wrapping prevents TypeCleaner breaking patterns - Defensive
-  conversion with warning for architectural violations
-
-3. ResponseHandlerGenerator (_get_base_schema_deserialization_code): - Added SANITY CHECK for
-  Optional[X] in response deserialization - New code path for modern X | None syntax handling -
-  Removed Optional from type checking and model detection - Maintains backward compatibility with
-  defensive conversion
-
-4. SchemaResolver: - Fixed null schema handling to respect required parameter - Changed
-  _resolve_any() to accept required parameter for correct optionality - Updated all Any fallbacks to
-  respect required throughout resolver chain
-
-5. ResponseResolver: - Modernised AsyncIterator[Dict[str, Any]] to AsyncIterator[dict[str, Any]] -
-  Removed unnecessary Dict import (uses lowercase dict)
-
-6. AliasGenerator & DataclassGenerator: - Removed duplicate TypeCleaner calls (already handled by
-  TypeFinalizer) - TypeFinalizer now performs cleaning in correct order - Added type hints to
-  dict-like methods (keys, values, items)
-
-Three-layer protection against Optional[X]: - Layer 1: UnifiedTypeService raises exception if
-  Optional[X] produced - Layer 2: TypeFinalizer logs error if Optional[X] received - Layer 3:
-  ResponseHandlerGenerator logs error if Optional[X] in deserialization
-
-Breaking changes: None (defensive conversions maintain compatibility)
-
-All tests passing: 1298 tests, zero regressions
-
 ### Testing
 
 - Update test assertions for modern Python 3.10+ type syntax
   ([`9644bf7`](https://github.com/mindhiveoy/pyopenapi_gen/commit/9644bf72d41769510b3d9a6774521ee5fd75b6c9))
 
-Update test expectations to align with unified type system's modern X | None syntax, removing
-  assertions for Optional import presence and modernising type checking patterns.
-
-Test changes:
-
-1. test_type_helper.py: - Removed 8 assertions checking for Optional import (not needed in Python
-  3.10+) - Updated finalize() expectations to use X | None syntax - Fixed Union type expectations:
-  Union[int, float] | None (not Optional[Union[...]])
-
-2. test_loader.py: - Updated regex to match modern dict[str, Any] (not Dict[str, Any]) - Updated
-  both params and query_params patterns
-
-3. test_endpoints_emitter.py: - Accept both Dict and dict in type checking - Removed strict Optional
-  import requirement
-
-4. test_models_emitter.py: - Updated datetime test: Python 3.10+ doesn't need Optional import -
-  Updated optional list factory test: only List import needed - Updated union anyof test: accepts
-  modern syntax
-
-5. test_type_cleaner.py: - Fixed test to use public API instead of private _clean_simple_patterns -
-  Tests now verify clean_type_parameters() public interface
-
-6. test_agent_include_parameter_typing.py: - Added circular reference placeholder detection - Test
-  now handles unified cycle detection properly
-
-7. test_response_resolver.py, test_schema_resolver.py, test_business_swagger_message_type.py: -
-  Updated type expectations for modern syntax - Removed Optional-specific assertions
-
-All test updates are assertion-only (no logic changes) Test results: 1298 tests passing, 2 warnings
-  (expected from edge case tests)
-
 - **regression**: Add comprehensive coverage for three critical bug classes
   ([`0b5a7ba`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0b5a7ba44d7b58007ef5ed0d446547ec34f8199f))
-
-Added 8 regression tests protecting against recently discovered bugs:
-
-1. JsonValue wrapper class generation (1 test) File: tests/visit/model/test_json_value_wrapper.py
-  Scenario: Schema with additionalProperties: {nullable: true} Bug: Generated empty class instead of
-  dict-like wrapper with __getitem__ Protection: Validates wrapper class structure and dict-like
-  interface
-
-2. Null schema resolution (4 tests) File: tests/types/test_schema_resolver.py Bug: Schemas with
-  type=None resolved to None instead of Any Impact: Type name collisions across unrelated fields in
-  generated code Tests cover: - test_resolve_schema__null_type_schema__returns_any -
-  test_resolve_schema__null_type_schema_optional__returns_any_with_optional_flag -
-  test_resolve_schema__schema_no_type_no_generation_name__returns_any -
-  test_resolve_schema__schema_no_type_but_has_generation_name__resolves_as_named
-
-3. Modern union syntax preservation (2 tests) File: tests/helpers/test_type_cleaner.py Bug:
-  Top-level unions "List[X] | None" truncated to "List[X] | Non]" Impact: 36 syntax errors in
-  business_swagger.json client Tests cover: -
-  test_clean_type_parameters__modern_union_syntax_with_list__preserves_full_type -
-  test_clean_type_parameters__modern_union_syntax_nested__handles_correctly
-
-4. Integration test (1 test) File: tests/visit/model/test_json_value_integration.py End-to-end
-  validation of wrapper generation pipeline
-
-Test execution results: - New tests: 8/8 PASSING - Total suite: 1278 passed - Coverage: 88.48%
-  (above 85% requirement) - Zero regressions introduced
-
-Protects against: business_swagger.json generation failures discovered in production
 
 
 ## v0.14.0 (2025-10-06)
@@ -1074,98 +2822,20 @@ Protects against: business_swagger.json generation failures discovered in produc
 - Remove legacy commands from development guide
   ([`396680e`](https://github.com/mindhiveoy/pyopenapi_gen/commit/396680e93f15cabc638af0a1170853cfa3d6e5de))
 
-Removed outdated "Legacy Commands" section from CLAUDE.md development guide as modern commands are
-  already documented in "Essential Commands" section.
-
-Technical Details: - Removed 5 lines of legacy command documentation - Deleted commands that are
-  superseded by Makefile targets: * pytest --cov=src --cov-report=html (use: make test-cov) * ruff
-  check --fix src/ (use: make lint-fix) * mypy src/ --strict (use: make typecheck) - Modern
-  equivalents already documented with better descriptions - Simplified development workflow
-  documentation
-
-Impact: - No functional changes - Documentation now clearer with single source of truth for commands
-  - Developers directed to use consistent Makefile targets
-
 ### Features
 
 - **exceptions**: Implement human-readable exception names and shared core registry
   ([`6983037`](https://github.com/mindhiveoy/pyopenapi_gen/commit/69830375a5a8e93b14c6cf2cf7b289093b57a346))
-
-Replaces generic numeric exception names with semantic, human-readable names and adds registry
-  system for multi-client shared core scenarios.
-
-Technical Details: - Created http_status_codes.py with comprehensive HTTP status code mapping (400 →
-  BadRequestError, 404 → NotFoundError, 500 → InternalServerError) - Exception classes now include
-  human-readable status names in docstrings - Filters out 2xx success codes from exception
-  generation (no error classes for successful responses using is_error_code() helper) - Implements
-  .exception_registry.json to track exceptions needed by each client in shared core scenarios -
-  Registry prevents last client from overwriting exceptions needed by earlier clients when multiple
-  clients share a core package - Generated exception_aliases.py is Ruff-compliant from generation
-  (proper import ordering with third-party before local, correct spacing)
-
-Breaking Changes: - Generated exception class names changed from Error{code} to semantic names
-  (Error404 → NotFoundError, Error401 → UnauthorisedError, etc.) - Affects generated client code but
-  not runtime behavior - ExceptionsEmitter.emit() now accepts optional client_package_name parameter
-  - ExceptionVisitor.visit() returns tuple of (code, names, status_codes) instead of (code, names)
-
-Migration Notes: - Regenerate all clients to get new human-readable exception names - No code
-  changes required for clients using exception handling - Registry file (.exception_registry.json)
-  automatically managed - Clients continue to catch exceptions the same way, just with better names
-
-Implementation: - HTTP_EXCEPTION_NAMES maps status codes to semantic class names -
-  get_exception_class_name() provides consistent name resolution - get_status_name() provides
-  human-readable descriptions - is_error_code() filters to only 4xx/5xx codes - Registry system uses
-  JSON to track multi-client exception requirements
 
 ### Performance Improvements
 
 - **postprocess**: Optimize Ruff execution with bulk operations (25x faster)
   ([`eed3c34`](https://github.com/mindhiveoy/pyopenapi_gen/commit/eed3c346da9ddbb9daa1d745e8bc8f8f46c6e9b6))
 
-Changed from per-file Ruff subprocess calls to bulk operations on all files, reducing generation
-  time from 120+ seconds to 5.4 seconds for large specs.
-
-Technical Details: - Added remove_unused_imports_bulk(), sort_imports_bulk(), format_code_bulk()
-  methods that process all files in a single subprocess call - Changed from 2,331 individual
-  subprocess calls to 3 bulk calls for 777 files - Performance improvement: 120+ seconds → 5.4
-  seconds (25x speedup) - Temporarily disabled mypy type checking for faster iteration
-  (configurable, can be re-enabled when full validation needed) - Fixed docstring empty line
-  handling in PythonConstructRenderer to avoid trailing whitespace (Ruff W293 compliance)
-
-Implementation Approach: - Subprocess.run() executes ruff with list of all file paths as arguments
-  instead of individual calls per file - Maintained existing error handling and output filtering
-  logic - Preserved per-file methods for backward compatibility - Empty lines in class body_lines
-  now use writer.newline() instead of write_line("") to prevent indentation on blank lines
-
-Performance Impact: - Large spec generation (777 files): 120s → 5.4s - No change to generated code
-  quality or Ruff compliance - All formatting, linting, and import organization still applied - Mypy
-  still available but disabled by default for speed
-
-Non-breaking Change: - Generated code quality unchanged - All existing functionality preserved -
-  Mypy can be re-enabled by uncommenting lines 63-68 in postprocess_manager.py
-
 ### Testing
 
 - Update exception tests for human-readable names
   ([`26e2aef`](https://github.com/mindhiveoy/pyopenapi_gen/commit/26e2aef9df2e713a1d4098608f7c191bcd5992ab))
-
-Updated all exception-related tests to expect new human-readable exception names instead of generic
-  numeric names (NotFoundError vs Error404).
-
-Technical Details: - Updated test_exceptions_emitter.py assertions: * Now expects NotFoundError
-  instead of Error404 * Now expects InternalServerError instead of Error500 * Added validation for
-  human-readable status descriptions in docstrings * Removed HTTPError import assertion (no longer
-  used in exception_aliases.py) - Updated test_response_handler_generator.py: * Changed Error404
-  assertions to NotFoundError * Updated test docstrings to reflect human-readable names - Updated
-  test_match_case_response.py: * Changed Error400/401/404/500 to BadRequestError/UnauthorisedError/
-  NotFoundError/InternalServerError - Updated test_response_handler_generator_strategy.py: * Changed
-  Error404/500 assertions to NotFoundError/InternalServerError
-
-Test Results: - All 1,280 tests passing (100% success rate) - Coverage maintained at 85%+ - All
-  exception-related assertions updated and verified - No test failures or regressions
-
-Changes Tested: - Exception class name generation - Exception docstring content - Import statements
-  in generated code - Response handler error raising - Match-case statement error handling
 
 
 ## v0.13.0 (2025-09-08)
@@ -1175,64 +2845,23 @@ Changes Tested: - Exception class name generation - Exception docstring content 
 - **parser**: Handle non-standard schema types automatically
   ([`b9a82bd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b9a82bd1fe5b1cde73c48a2c8e3148506fb5d029))
 
-- Convert 'Any' type to 'object' with helpful warning messages - Convert 'None' type to nullable
-  object with guidance - Default schemas without explicit type to 'object' per OpenAPI spec - Use
-  'object' instead of 'Any' for arrays without items specification - Infer type from enum values
-  when type is missing - Fix empty composition handling (anyOf/allOf/oneOf with empty arrays) -
-  Update tests to match improved type handling behavior
-
-These changes eliminate the 'Unknown schema type' errors for 'Any' and 'None' that were appearing
-  during client generation, making the generator more robust when handling non-standard or
-  incomplete OpenAPI specifications.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 ### Code Style
 
 - Apply Black formatting to fix CI
   ([`7a89d96`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7a89d96c7eeddaa80cb624ae394c70f574c419bb))
 
-Applied Black formatting to schema_parser.py and schema_resolver.py to pass the CI quality checks.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 - Remove unused import to fix CI
   ([`82334e9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/82334e99d1aa196d316f71d7a36085bc5f6c35fb))
-
-Removed unused Optional import from schema_resolver.py that was causing ruff linting to fail in CI.
 
 ### Documentation
 
 - Add comprehensive release automation documentation
   ([`46f6f37`](https://github.com/mindhiveoy/pyopenapi_gen/commit/46f6f37d5b933db620f57627d48d4e785f63f6b9))
 
-- Document how semantic-release automation works - Explain conventional commit triggers for version
-  bumps - Show real example of v0.12.1 hotfix release - Include configuration details and best
-  practices - Add troubleshooting guide for common issues
-
-This ensures team members understand how to trigger automatic releases and why fixes are immediately
-  available to users.
-
 ### Features
 
 - **errors**: Enhance error reporting for unknown schema types
   ([`0f199e5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0f199e511a0d3c2d3bac0db439411dfceab5e8d4))
-
-- Add detailed error messages with full schema context - Include actionable guidance for common
-  issues - Provide specific suggestions based on the unknown type - Help users identify and fix
-  OpenAPI spec issues quickly
-
-Examples of improved messages: - Unknown type 'Any' → Suggests using specific types - Unknown type
-  'None' → Explains optional field mapping - Custom types → Lists common causes and solutions -
-  Missing items in arrays → Shows correct syntax - Missing final_module_stem → Explains processing
-  issues
-
-This makes debugging OpenAPI spec issues much easier by providing clear, actionable error messages
-  instead of generic warnings.
 
 
 ## v0.12.1 (2025-09-07)
@@ -1242,29 +2871,10 @@ This makes debugging OpenAPI spec issues much easier by providing clear, actiona
 - **parser**: Register inline enum array parameters in parsed_schemas
   ([`b1629e2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b1629e27cce4773e9bec1bb3ac92eeb858a4fa38))
 
-Critical fix for inline enum array parameters not generating importable model files.
-
-Root cause: - Inline enum schemas in array parameters were created but never registered - Missing
-  final_module_stem attribute prevented proper import generation - Generated clients failed with
-  NameError when importing enum types
-
-Solution: - Register inline enum schemas in context.parsed_schemas - Set final_module_stem for
-  proper import path generation - Add comprehensive test coverage for inline enum parameters
-
-Impact: - All inline enum array parameters now generate proper model files - Generated clients can
-  be imported without NameError - Fixes business_swagger.json generation issues
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 ### Code Style
 
 - Apply Black formatting and fix linting issues
   ([`1252f3b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1252f3bfa37568ba9743f283b6cceb3b52a54a1d))
-
-- Apply Black formatting to maintain code style consistency - Remove unused imports flagged by Ruff
-  - All quality checks passing except low-severity security issues
 
 
 ## v0.12.0 (2025-09-07)
@@ -1274,42 +2884,16 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - **parser**: Properly handle inline enums in array parameters
   ([`ea4b258`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ea4b258ade22cd7448047eeda83d86afb74c354e))
 
-- Enhanced warning messages to show enum values and context for better debugging - Fixed parameter
-  parser to properly name and mark inline enum items in array parameters - Added generation_name
-  attribute to inline enum schemas to mark them as promoted - Component parameters with array items
-  containing enums now generate proper Enum types
-
-BREAKING CHANGE: None - this is a bug fix that improves enum handling
-
 - **security**: Replace assert statements with proper error handling
   ([`532cb41`](https://github.com/mindhiveoy/pyopenapi_gen/commit/532cb41b2ca513f5ff5ac64ee9d64eb468c7b0db))
-
-- Replace all assert statements with if/raise patterns to pass security checks - Use TypeError for
-  type checking violations - Use ValueError for value validation failures - Use RuntimeError for
-  other runtime conditions - Update tests to expect appropriate error types instead of
-  AssertionError - Maintains zero-error security policy for production code
-
-This change ensures assert statements won't be removed in optimized bytecode and provides proper
-  error handling throughout the codebase.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 
 ### Chores
 
 - **deps**: Update typer and click dependencies
   ([`da2d03a`](https://github.com/mindhiveoy/pyopenapi_gen/commit/da2d03a233153f25b3d1d95460da79da935ce455))
 
-- Remove upper version constraint for typer (was <0.14.0) - Remove upper version constraint for
-  click (was <9.0.0) - Update poetry.lock to match new constraints - Allows using latest stable
-  versions of these dependencies
-
 - **git**: Add test_output directory to gitignore
   ([`1063e77`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1063e77fdce39b5a5bbdf21a8734427a7700e80d))
-
-- Add test_output/ to gitignore alongside test_outputs - Prevents temporary test artifacts from
-  being tracked
 
 ### Code Style
 
@@ -1324,16 +2908,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - Skip integration test with inline enum parameter issue
   ([`1b37271`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1b37271f2daca9a4f7bbea9b6da615dbd7f0c2ff))
 
-The business_swagger integration test is failing due to the same inline enum array parameter issue -
-  these types are referenced but not properly generated or imported. Skipping temporarily to allow
-  the security fix release to proceed.
-
 - Skip known issue test for inline enum arrays in parameters
   ([`c6a8f70`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c6a8f70d5827a14740c9faecab71553bee42669d))
-
-The test revealed a real issue where inline enum arrays in parameters are not properly handled -
-  they lack final_module_stem attribute and aren't generated as actual enum files. Skipping this
-  test temporarily to allow the security fix release to proceed.
 
 
 ## v0.11.0 (2025-09-06)
@@ -1349,47 +2925,19 @@ The test revealed a real issue where inline enum arrays in parameters are not pr
 - **parser**: Enhance parameter resolution to prefer component schemas
   ([`743f6d4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/743f6d46d86f7288ddfeabf1c2896f6a698fccda))
 
-- Add fallback to component parameters when inline schemas are basic - Prefer richer component
-  schemas (arrays/enums/refs) over simple inline ones - Handle simple enum arrays in parameters
-  without creating complex schemas - Improve parameter type resolution for better client generation
-
 - **types**: Improve enum resolution to handle promoted schemas
   ([`e44d358`](https://github.com/mindhiveoy/pyopenapi_gen/commit/e44d358e5a995a0a93ca19aa3f24ff53855a1666))
 
-Updated schema resolver to properly recognize promoted enum schemas and reduce false-positive
-  warnings.
-
-Implementation changes: - Check for generation_name or _is_top_level_enum marker - Return enum type
-  name for properly processed enums - Log more informative warnings with schema names - Preserve
-  fallback to str for truly inline enums
-
-Technical details in schema_resolver.py: - Modified _resolve_string() to check promotion markers -
-  Return generation_name or name for marked enums - Only warn for unmarked inline enums with
-  descriptive message
-
-This eliminates spurious warnings for properly promoted enums while maintaining detection of actual
-  inline enum issues.
-
 - **visit**: Add fallback for missing response descriptions
   ([`5c9b853`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5c9b853c7cdab4afa5d49adf1c8e8f186e39b6e8))
-
-- Handle None response descriptions gracefully in signature generator - Provide empty string
-  fallback to prevent AttributeError - Improve robustness when OpenAPI specs have incomplete
-  response metadata
 
 ### Chores
 
 - Update build configuration for coverage reports
   ([`0e6f0ff`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0e6f0ff95c9dbaba0a5920d608641ce29ab1d870))
 
-- Add coverage_reports/ directory to .gitignore - Update Makefile coverage targets to use
-  coverage_reports/ for data storage - Prevent coverage data files from polluting project root
-
 - **deps**: Update project dependencies
   ([`e4a1469`](https://github.com/mindhiveoy/pyopenapi_gen/commit/e4a146996d1486194ca9503c0788434ba6df409d))
-
-- Update anyio to 4.9.0 for improved async functionality - Update authlib to 1.4.0 for better OAuth2
-  support - Sync poetry.lock with latest dependency resolutions
 
 ### Code Style
 
@@ -1404,76 +2952,27 @@ This eliminates spurious warnings for properly promoted enums while maintaining 
 - **enums**: Add support for top-level enum schema promotion
   ([`92afb7c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/92afb7c1964d85def7c8432f56d831d5bfa50a81))
 
-Enhanced enum extraction to properly handle top-level enum schemas defined directly in OpenAPI
-  components/schemas (like UserRole, TenantStatus).
-
-Implementation details: - Modified extract_inline_enums() to detect and mark top-level enums - Set
-  generation_name for top-level enums to ensure proper code generation - Added _is_top_level_enum
-  marker for tracking promoted schemas - Preserved existing inline enum extraction from properties
-
-Technical changes in extractor.py: - Added check for schemas with enum values and primitive types -
-  Automatically set generation_name if not already present - Mark schemas with _is_top_level_enum =
-  True for resolver
-
-This ensures all enum schemas generate proper Python Enum classes instead of falling back to plain
-  string types.
-
-Addresses: Inline enum promotion warnings in business_swagger.json
-
 ### Refactoring
 
 - **core**: Improve exception handling with optional response object
   ([`466706f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/466706fb2cf9dbc43f374c5e51548c6c7111efd2))
 
-- Make response parameter optional in HTTPError constructor - Use Union[object, None] type
-  annotation for Python 3.12 compatibility - Enhance error handling flexibility for generated
-  clients
-
 - **generator**: Improve logging and JSON serialization
   ([`30bf5a4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/30bf5a4ef36df27f3d348f17dbb6fd519b450b88))
 
-- Fix JSONEncoder override method name from 'default' to 'encode' - Add debug logging for spec
-  loading with truncated output - Improve error handling in spec serialization - Enhance debugging
-  capabilities for complex OpenAPI specs
-
 - **loader**: Improve spec validation error handling
   ([`d42cb7d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d42cb7da9a8ad5244b8d56285bd7614391b51ef9))
-
-- Add heuristic detection for jsonschema and openapi_spec_validator errors - Use logger.warning for
-  known validation library errors - Preserve explicit warnings for unexpected validation failures -
-  Reduce noise in test output while maintaining error visibility
 
 ### Testing
 
 - Add comprehensive business domain OpenAPI spec
   ([`1710abe`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1710abe46521e148da8217f8236252fe9e93514a))
 
-- Include complex schemas with enums, arrays, and nested objects - Add multi-status response
-  definitions for testing - Include examples of inline and referenced enums - Provide realistic test
-  cases for parameter resolution
-
 - Enhance type resolution test coverage
   ([`9a0a4e5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/9a0a4e5933a2a20f5aab9e08d77a442768f1a053))
 
-- Add comprehensive tests for enum resolution scenarios - Improve test assertions for optional type
-  handling - Add edge cases for complex schema resolution - Enhance test documentation with clear
-  scenario descriptions
-
 - **enums**: Add comprehensive tests for enum promotion feature
   ([`8cd7eb2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8cd7eb2b61cce36fb01f495ad4ee689c6e09d75b))
-
-Added test coverage for top-level enum extraction and resolution to ensure proper handling of
-  various enum patterns.
-
-Test coverage includes: - Top-level string, integer, and number enum schemas - Preservation of
-  existing generation_name values - Mixed scenarios with top-level and inline enums - Schema
-  resolver handling of promoted enums - Warning generation for unprocessed inline enums - Edge cases
-  like object types with enum values
-
-Test files: - test_top_level_enum_extraction.py: 6 test cases - test_schema_resolver_enums.py: 7
-  test cases
-
-All tests pass and verify correct enum promotion behavior.
 
 
 ## v0.10.2 (2025-07-17)
@@ -1483,12 +2982,6 @@ All tests pass and verify correct enum promotion behavior.
 - **docs**: Update CLAUDE.md with recent publishing automation improvements
   ([`a3eb8d2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/a3eb8d24e08e90f38bfa83c7024941a14ae3e599))
 
-Document the successful implementation of: - Twine-based PyPI publishing workflow - Enhanced token
-  validation and error handling - Automated branch synchronization system - PYPI_API_TOKEN secret
-  configuration
-
-This update ensures the documentation reflects the current robust CI/CD publishing state.
-
 
 ## v0.10.1 (2025-07-17)
 
@@ -1496,13 +2989,6 @@ This update ensures the documentation reflects the current robust CI/CD publishi
 
 - **ci**: Add comprehensive PyPI token validation and version conflict detection
   ([`8a096d5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8a096d5c6a30be7021578bfd904f5e61ffc23d27))
-
-- Add dedicated PYPI_API_TOKEN secret validation step - Implement version conflict detection to
-  prevent duplicate uploads - Rebuild packages after semantic-release version bump to ensure correct
-  versions - Add timeout protection and better error messaging for PyPI uploads - Enhance debugging
-  output for troubleshooting authentication issues
-
-Resolves: PyPI upload hanging due to version conflicts and improper token validation
 
 
 ## v0.10.0 (2025-07-17)
@@ -1512,51 +2998,6 @@ Resolves: PyPI upload hanging due to version conflicts and improper token valida
 - **ci**: Implement robust twine-based publishing with automated branch synchronization
   ([`2fe82b1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/2fe82b18b8e830cdbadea99e178c9e3c1aeb7350))
 
-Replace unreliable Poetry publishing with enterprise-grade twine-based automation that resolves
-  persistent 'No module named build' and PyPI authentication failures.
-
-## Key Improvements
-
-### Publishing Infrastructure - Add comprehensive Makefile publish targets (publish, publish-test,
-  publish-force, publish-check) - Replace semantic-release PyPI publishing with dedicated twine
-  workflow - Implement explicit token extraction from Poetry auth configuration - Add robust error
-  handling and validation for all publish operations
-
-### GitHub Actions Enhancements - Migrate from poetry publish to twine upload with PYPI_API_TOKEN -
-  Add automated branch synchronization (main → staging → develop) after releases - Implement smart
-  conflict resolution with automatic PR creation - Add comprehensive release summaries and status
-  reporting
-
-### Developer Experience - Provide multiple publish modes for different development scenarios - Add
-  token validation and clear error messages for authentication issues - Support both production PyPI
-  and TestPyPI publishing workflows - Enable force publishing for CI/CD environments
-
-### Configuration Updates - Add twine ^6.0.1 to development dependencies - Configure
-  semantic-release for version-only operations (no publishing) - Update workflow permissions and
-  environment variable handling - Fix deprecated Poetry sync flag in Makefile dependency management
-
-## Technical Details
-
-The new architecture separates concerns: semantic-release handles versioning and changelog
-  generation, while twine handles reliable PyPI publishing. This resolves Docker container isolation
-  issues that prevented Poetry from accessing the build module in GitHub Actions.
-
-Branch synchronization ensures develop and staging environments automatically receive version
-  updates after successful releases, with graceful fallback to pull requests when merge conflicts
-  occur.
-
-## Breaking Changes
-
-None - all existing workflows remain functional while gaining reliability improvements.
-
-Resolves: persistent semantic-release PyPI authentication failures
-
-Resolves: 'No module named build' errors in GitHub Actions
-
-Resolves: manual branch synchronization after releases
-
-Implements: enterprise-grade publishing automation
-
 
 ## v0.9.0 (2025-07-17)
 
@@ -1565,237 +3006,84 @@ Implements: enterprise-grade publishing automation
 - Auto-format code with black
   ([`25362a2`](https://github.com/mindhiveoy/pyopenapi_gen/commit/25362a21ba94277614648e8c6a43ae109bd8857c))
 
-- Fix formatting issue in test_edge_cases_integration.py - All quality gates now passing
-
 - Clean up .gitignore formatting
   ([`dce7a47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/dce7a47ab987554c6d3ec46543265481b0955dda))
-
-Add proper newline ending and ensure _process/ is properly excluded from version control.
 
 - Convert .bandit configuration from INI to YAML format
   ([`a40df8f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/a40df8f9f9c879cea1d82a8a99b21ba947174ed4))
 
-- Fix YAML parsing error in bandit security configuration - Convert from INI format to proper YAML
-  format - Security scan now runs successfully with 0 issues found
-
 - Resolve all test failures and improve async support
   ([`a10502b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/a10502bacc65730bbed0124d8a78eea7516ca30c))
-
-- Add pytest-asyncio dependency and configure asyncio_mode = "auto" - Fix ModelVisitor test
-  assertions for single quote field mappings - Fix utils test sys.modules cleanup logic - Add
-  no_postprocess=True to integration test to skip missing dependencies - All 1,265 tests now pass
-  (previously 31 failures)
-
-Quality gates: ✅ Tests passing, ready for PR
 
 - Resolve CLI test failures and f-string issues in tests
   ([`dea0113`](https://github.com/mindhiveoy/pyopenapi_gen/commit/dea011332975052df7cf57bb96b2a9c9e84f781d))
 
-Fix failing CLI tests and f-string syntax errors in test files:
-
-CLI Test Improvements: - test_cli_edge_cases.py: Replace subprocess calls with Typer testing
-  framework - test_http_pagination_cli.py: Use CliRunner for reliable CLI testing - Add graceful
-  fallback for environment setup issues
-
-Test F-String Fixes: - Fix nested quotes in f-strings across test files - Resolve dictionary access
-  patterns in test assertions - Fix string formatting in integration tests
-
-Impact: - All 1,265 tests now pass successfully - CLI tests are more reliable and faster - Test
-  suite runs without syntax errors - Improved CI/CD compatibility
-
 - Resolve f-string syntax errors across codebase
   ([`4248061`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4248061f2905d868bcd3b3467359f49e6ea34118))
-
-Fix f-string syntax errors that were preventing code from loading:
-
-Core Issues Fixed: - Nested double quotes in f-strings: f"text {dict["key"]}" → f"text
-  {dict['key']}" - Join operations in f-strings: f"text {", ".join(items)}" → f"text {',
-  '.join(items)}" - Mixed quote patterns causing parse errors
-
-Files Updated: - context/import_collector.py: Fixed relative import generation -
-  core/loader/operations/parser.py: Fixed response description generation - core/parsing/: Fixed
-  schema parsing and cycle detection messages - helpers/: Fixed type resolution and utility
-  functions - visit/endpoint/: Fixed code generation for endpoints - types/resolvers/: Fixed schema
-  resolution union types
-
-This resolves the syntax errors that prevented 1,265 tests from running, enabling the full test
-  suite to execute successfully.
 
 - Standardize field mapping quotes to double quotes in code generation
   ([`a789381`](https://github.com/mindhiveoy/pyopenapi_gen/commit/a789381081fe10df885136c3e096cc6ab527fe79))
 
-Root cause fix for CI test failures: - Fix PythonConstructRenderer to generate double quotes in
-  field mappings - Update all test assertions to expect double quotes consistently - Resolves quote
-  style mismatch between local and CI environments
-
-Before: 'field': 'mapped_field',
-
-After: "field": "mapped_field",
-
-All 1,265 tests now pass consistently across environments.
+- **build**: Use python -m build instead of poetry build for semantic release
+  ([#47](https://github.com/mindhiveoy/pyopenapi_gen/pull/47),
+  [`8243b69`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8243b699172995519553e33cd5afe7d437164376))
 
 - **ci**: Enable ci.yml for PRs to provide required test status check
   ([`84e1283`](https://github.com/mindhiveoy/pyopenapi_gen/commit/84e1283471111f6ddc6b481b6f6c8c26d2313007))
 
-- Branch protection requires 'test' status check on PRs - Added pull_request trigger for
-  staging/develop/main PRs - Minimal implementation that just satisfies branch protection - Actual
-  testing still handled by pr-checks.yml for PRs - This unblocks PR merging while avoiding test
-  duplication
-
 - **ci**: Ensure Poetry is available in PATH for semantic-release build command
-  ([`0a68f6e`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0a68f6e4ace7fb998c4ddec14c7cf67713d7ce73))
-
-- Add explicit PATH setup for Poetry before semantic-release step - Add verification step to confirm
-  Poetry availability - Fixes 'poetry: command not found' error in semantic release pipeline -
-  Resolves build command failure preventing automated releases
+  ([#47](https://github.com/mindhiveoy/pyopenapi_gen/pull/47),
+  [`8243b69`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8243b699172995519553e33cd5afe7d437164376))
 
 - **ci**: Ensure Poetry is available in PATH for semantic-release build command
   ([#46](https://github.com/mindhiveoy/pyopenapi_gen/pull/46),
   [`3734aac`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3734aacb74eda746375c7d88c45715a1f18f33a1))
 
-- Add explicit PATH setup for Poetry before semantic-release step - Add verification step to confirm
-  Poetry availability - Fixes 'poetry: command not found' error in semantic release pipeline -
-  Resolves build command failure preventing automated releases
+- **ci**: Ensure Poetry is available in PATH for semantic-release build command
+  ([`0a68f6e`](https://github.com/mindhiveoy/pyopenapi_gen/commit/0a68f6e4ace7fb998c4ddec14c7cf67713d7ce73))
 
 - **ci**: Resolve semantic-release build failure with separate build step
   ([#49](https://github.com/mindhiveoy/pyopenapi_gen/pull/49),
   [`70f0d7a`](https://github.com/mindhiveoy/pyopenapi_gen/commit/70f0d7a971a82c7c2b54df9419a3635a6012966b))
 
-- Replace python-semantic-release GitHub Action with native Poetry build - Add separate build step
-  using 'poetry run python -m build' - Run semantic-release with --skip-build flag to use pre-built
-  packages - Remove build_command from pyproject.toml configuration - Fix deprecated 'angular'
-  parser warning by switching to 'conventional' - Split semantic-release into version and publish
-  steps for better control
-
-This fixes the persistent 'No module named build' error in the semantic-release Docker container by
-  building packages in the Poetry environment first, then using those pre-built packages for release
-  processing.
-
 - **ci**: Restore minimal ci.yml to satisfy required branch protection
   ([`ee28f45`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ee28f4532feb2ef16bb0163ed30669d635fcbfa9))
-
-- Branch protection rules require 'test' status check from ci.yml - Modified to minimal
-  implementation that only runs on main pushes - Eliminates duplication while satisfying branch
-  protection requirements - Actual testing still handled by semantic-release.yml for main pushes -
-  PRs still handled by pr-checks.yml to avoid redundancy
 
 - **deps**: Add missing pytest plugins for testing infrastructure
   ([`9dd1557`](https://github.com/mindhiveoy/pyopenapi_gen/commit/9dd15578c7570ea9c342752a87ac10cdf38b26b1))
 
-- Add pytest-xdist for parallel test execution - Add pytest-cov for coverage reporting - Update
-  poetry.lock with new dependencies - All quality gates now pass: format, lint, typecheck, security,
-  tests (90.34% coverage)
-
 - **deps**: Regenerate poetry.lock to include build module dependency
   ([`b54085b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b54085b05e4b1417e430f710826b6af4f5640bbc))
-
-- poetry.lock was missing build module causing CI failures - pyproject.toml changed significantly
-  since poetry.lock was last generated - Fixes semantic release workflow failure in dependency
-  installation - Build dependency is required for 'python -m build' command
 
 ### Chores
 
 - Regenerate poetry.lock after merge
   ([`ca45694`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ca456943afb7e1e1aa6f8eb447171017fc2a3da5))
 
-Update poetry.lock to reflect merged dependencies and resolve lock file conflicts from merge.
-
 - Remove temporary debug files and process artifacts
   ([`6055bd7`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6055bd7dd71a163ce9f08ddb5596b89092c5ffb0))
-
-Remove debug and analysis files that were created during development: - RELEASE_NOTES_v0.8.5.md -
-  RESPONSE_RESOLUTION_REFACTOR.md - TEST_MAP.md - debug_*.py files (after_fix, data_schema_names,
-  list_issue, signature_issue, strategy_resolver)
-
-These files were used for debugging and analysis but are not needed in the repository.
 
 - Update .gitignore to exclude temporary files
   ([`7d1f7fb`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7d1f7fbf8370b1575a7346a9f67d389ef7a84a82))
 
-Add _process/ and .deps-installed to .gitignore:
-
-- _process/: Temporary AI agent work directory for process artifacts - .deps-installed: Makefile
-  dependency tracking file
-
-These files are generated during development but should not be tracked in version control.
-
 - **ci**: Remove redundant workflows to eliminate test duplication
   ([`ee0bbdd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ee0bbdde9e033684cd29e55db1eaa48d2b56dcf7))
-
-- Remove ci.yml (redundant with pr-checks.yml for PR validation) - Remove main-checks.yml (redundant
-  with semantic-release.yml for main pushes) - This reduces CI execution time by ~66% and prevents
-  resource waste - Clean separation: semantic-release.yml for main, pr-checks.yml for PRs
 
 ### Documentation
 
 - Add module-specific CLAUDE.md documentation files
   ([`e3f9ef6`](https://github.com/mindhiveoy/pyopenapi_gen/commit/e3f9ef6d945519c9c81f18f86debb83ac413c0b0))
 
-Add comprehensive documentation files for each major module:
-
-- context/CLAUDE.md: Context management and import handling - core/CLAUDE.md: Core parsing, loading,
-  and schema processing - emitters/CLAUDE.md: Code emission and file generation -
-  generator/CLAUDE.md: Client generation orchestration - helpers/CLAUDE.md: Type resolution and
-  utility functions - types/CLAUDE.md: Unified type resolution system architecture -
-  visit/CLAUDE.md: Code generation visitors and AST creation
-
-These files provide detailed context and guidance for AI agents and developers working on specific
-  parts of the codebase.
-
 - Update development documentation and setup guide
   ([`fd27c1c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fd27c1c6a73861e341e0f6fac49cf4fb648587f4))
-
-Update CLAUDE.md with comprehensive development guidance:
-
-Development Environment: - Add clear virtual environment activation instructions - Document Poetry
-  workflow and dependency management - Include troubleshooting for common setup issues - Add quality
-  gates and testing procedures
-
-Architecture Documentation: - Document unified type resolution system - Explain cycle detection and
-  resolution strategies - Add mermaid diagrams for system visualization - Include enterprise-grade
-  feature explanations
-
-Developer Experience: - Add quick start examples with real code - Document multi-client setups with
-  shared core - Include CLI usage patterns and project structure - Add troubleshooting for common
-  developer issues
-
-Standards: - Document testing requirements and conventions - Include code quality standards and
-  tools - Add commit message and documentation conventions
-
-This provides comprehensive guidance for developers and AI agents working with the codebase.
 
 ### Features
 
 - Improve build system and development environment setup
   ([`a913745`](https://github.com/mindhiveoy/pyopenapi_gen/commit/a91374524ec54621b83285714ec3841c96c5c03a))
 
-Enhance Poetry configuration and development workflow:
-
-Poetry Configuration: - Fix Python version requirement to 3.12.x specifically - Consolidate
-  dependencies and remove mixed build system configuration - Add missing pytest plugins
-  (pytest-xdist, pytest-timeout) - Update dependency versions for compatibility
-
-Makefile Enhancements: - Add automatic dependency management with .deps-installed tracking - Improve
-  make targets with better error handling - Add dev-setup target for one-time environment setup -
-  Ensure Poetry uses local virtual environment
-
-Quality Gates: - Configure Bandit to skip Design by Contract assertions (B101) - Add security check
-  configuration for trusted subprocess calls - Improve security scanning with project-specific rules
-
-Development Experience: - Pin Python 3.12 with .python-version file - Eliminate manual 'poetry
-  install' requirements - Make 'make test' and 'make quality' work reliably - All 1,265 tests pass
-  with 90%+ coverage - All quality gates pass without manual intervention
-
 - **ci**: Implement semantic release automation with conventional commits
   ([`c68a81e`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c68a81e20895cccb23ab9cdb7f6f9084fdb9742f))
-
-- Add semantic-release and commitizen dependencies - Configure automatic version bumping based on
-  commit messages - Create semantic-release.yml workflow for automated releases - Update existing
-  workflows to avoid conflicts - Add comprehensive documentation for release process - Support for
-  automatic CHANGELOG.md generation - Integration with PyPI publishing pipeline
-
-BREAKING CHANGE: Release process now requires conventional commit format for automatic versioning.
-  Manual version bumping is deprecated.
 
 ### Breaking Changes
 
@@ -1816,26 +3104,10 @@ BREAKING CHANGE: Release process now requires conventional commit format for aut
 - Add Claude GitHub App configuration documentation
   ([`49964ef`](https://github.com/mindhiveoy/pyopenapi_gen/commit/49964ef7751ac88ef523f9b6954a53452da99b74))
 
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 ### Features
 
 - Enhance Claude GitHub App configuration for PR approvals
   ([`f5c6b2e`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f5c6b2ecb31b573e8df48de036d5a116b62d93bc))
-
-- Enable formal PR reviews and auto-approval in claude.yml - Add support for staging and main
-  branches in claude-review-trigger.yml - Create claude-auto-approve.yml for automatic PR approval
-  workflow - Update review request messages to request formal GitHub approvals - Add allowed_tools
-  configuration for PR approval capabilities
-
-This should resolve: 1. Claude providing comments instead of formal PR reviews 2. @claude mentions
-  not triggering on staging/main PRs 3. Branch protection requiring formal approvals
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 
 
 ## v0.8.6 (2025-06-12)
@@ -1846,224 +3118,124 @@ Co-Authored-By: Claude <noreply@anthropic.com>
   ([#33](https://github.com/mindhiveoy/pyopenapi_gen/pull/33),
   [`497f5fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/497f5fa0ccdec88f90d515adc5c3fddaa4ed40e7))
 
-* chore: Bump version to 0.8.7
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-* feat: Enhance Claude GitHub App configuration for PR approvals
-
-- Enable formal PR reviews and auto-approval in claude.yml - Add support for staging and main
-  branches in claude-review-trigger.yml - Create claude-auto-approve.yml for automatic PR approval
-  workflow - Update review request messages to request formal GitHub approvals - Add allowed_tools
-  configuration for PR approval capabilities
-
-This should resolve: 1. Claude providing comments instead of formal PR reviews 2. @claude mentions
-  not triggering on staging/main PRs 3. Branch protection requiring formal approvals
-
-* docs: Add Claude GitHub App configuration documentation
-
-* fix: Correct f-string syntax error in import_collector.py
-
-Fix malformed f-string syntax in import statement generation that was causing syntax errors during
-  client generation. Changed incorrect f"from {module_name} import {", ".join(names)}" to proper
-  f"from {module_name} import {', '.join(names)}" syntax.
-
-* fix: Improve Claude GitHub App configuration for auto-approval
-
-- Remove unsupported auto_approve and create_review parameters - Add proper direct_prompt for Claude
-  Code Action - Update auto-approve workflow to trigger after Claude completion - Add support for
-  hotfix branch auto-approval - Improve PR detection for workflow_run events - Fix auto-approval
-  logic for different PR types
-
----------
-
-Co-authored-by: mindhivefi <ville@mindhive.fi>
-
-Co-authored-by: Claude <noreply@anthropic.com>
+- Correct f-string syntax error in import_collector.py
+  ([#34](https://github.com/mindhiveoy/pyopenapi_gen/pull/34),
+  [`08eae74`](https://github.com/mindhiveoy/pyopenapi_gen/commit/08eae74541dbb529cab01ba202ada0333fe2b4f7))
 
 - Correct f-string syntax error in import_collector.py (#33)
   ([#34](https://github.com/mindhiveoy/pyopenapi_gen/pull/34),
   [`08eae74`](https://github.com/mindhiveoy/pyopenapi_gen/commit/08eae74541dbb529cab01ba202ada0333fe2b4f7))
 
-* chore: Bump version to 0.8.7
+- Improve Claude GitHub App configuration for auto-approval
+  ([#33](https://github.com/mindhiveoy/pyopenapi_gen/pull/33),
+  [`497f5fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/497f5fa0ccdec88f90d515adc5c3fddaa4ed40e7))
 
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-* feat: Enhance Claude GitHub App configuration for PR approvals
-
-- Enable formal PR reviews and auto-approval in claude.yml - Add support for staging and main
-  branches in claude-review-trigger.yml - Create claude-auto-approve.yml for automatic PR approval
-  workflow - Update review request messages to request formal GitHub approvals - Add allowed_tools
-  configuration for PR approval capabilities
-
-This should resolve: 1. Claude providing comments instead of formal PR reviews 2. @claude mentions
-  not triggering on staging/main PRs 3. Branch protection requiring formal approvals
-
-* docs: Add Claude GitHub App configuration documentation
-
-* fix: Correct f-string syntax error in import_collector.py
-
-Fix malformed f-string syntax in import statement generation that was causing syntax errors during
-  client generation. Changed incorrect f"from {module_name} import {", ".join(names)}" to proper
-  f"from {module_name} import {', '.join(names)}" syntax.
-
-* fix: Improve Claude GitHub App configuration for auto-approval
-
-- Remove unsupported auto_approve and create_review parameters - Add proper direct_prompt for Claude
-  Code Action - Update auto-approve workflow to trigger after Claude completion - Add support for
-  hotfix branch auto-approval - Improve PR detection for workflow_run events - Fix auto-approval
-  logic for different PR types
-
----------
-
-Co-authored-by: Ville Venäläinen <ville@mindhive.fi>
-
-Co-authored-by: Claude <noreply@anthropic.com>
+- Improve Claude GitHub App configuration for auto-approval
+  ([#34](https://github.com/mindhiveoy/pyopenapi_gen/pull/34),
+  [`08eae74`](https://github.com/mindhiveoy/pyopenapi_gen/commit/08eae74541dbb529cab01ba202ada0333fe2b4f7))
 
 - Pin typer and click versions for compatibility
   ([`a2a04af`](https://github.com/mindhiveoy/pyopenapi_gen/commit/a2a04afe032ebc1697139f065d85ab84de385289))
 
-- Constrain typer to >=0.12.0,<0.14.0 to avoid breaking changes in v0.14+ - Constrain click to
-  >=8.0.0,<9.0.0 for stable compatibility - Ensures typer/click work together consistently across
-  environments - Prevents issues from automatic upgrades to incompatible versions
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 - Update poetry.lock file to match loosened dependency constraints
   ([`bcc471d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bcc471dc550c30ce755841e9199eabd0256459c6))
 
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 ### Chores
+
+- Bump version to 0.8.7 ([#33](https://github.com/mindhiveoy/pyopenapi_gen/pull/33),
+  [`497f5fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/497f5fa0ccdec88f90d515adc5c3fddaa4ed40e7))
+
+- Bump version to 0.8.7 ([#34](https://github.com/mindhiveoy/pyopenapi_gen/pull/34),
+  [`08eae74`](https://github.com/mindhiveoy/pyopenapi_gen/commit/08eae74541dbb529cab01ba202ada0333fe2b4f7))
 
 - Bump version to 0.8.7
   ([`80bbd3d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/80bbd3db7ff149638db15f6732c2a1c3c72f84be))
 
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 - Update poetry.lock after dependency constraints
   ([`b7dd6cd`](https://github.com/mindhiveoy/pyopenapi_gen/commit/b7dd6cd6897ff7d0e3afadfe34dabefe255f3aa5))
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 
 ### Continuous Integration
 
 - Bump codecov/codecov-action from 4 to 5
   ([`634f7d5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/634f7d5da915abb01d05e29e97153c87be06c600))
 
-Bumps [codecov/codecov-action](https://github.com/codecov/codecov-action) from 4 to 5. - [Release
-  notes](https://github.com/codecov/codecov-action/releases) -
-  [Changelog](https://github.com/codecov/codecov-action/blob/main/CHANGELOG.md) -
-  [Commits](https://github.com/codecov/codecov-action/compare/v4...v5)
+### Documentation
 
---- updated-dependencies: - dependency-name: codecov/codecov-action dependency-version: '5'
+- Add Claude GitHub App configuration documentation
+  ([#33](https://github.com/mindhiveoy/pyopenapi_gen/pull/33),
+  [`497f5fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/497f5fa0ccdec88f90d515adc5c3fddaa4ed40e7))
 
-dependency-type: direct:production
-
-update-type: version-update:semver-major ...
-
-Signed-off-by: dependabot[bot] <support@github.com>
+- Add Claude GitHub App configuration documentation
+  ([#34](https://github.com/mindhiveoy/pyopenapi_gen/pull/34),
+  [`08eae74`](https://github.com/mindhiveoy/pyopenapi_gen/commit/08eae74541dbb529cab01ba202ada0333fe2b4f7))
 
 ### Features
 
+- Enhance Claude GitHub App configuration for PR approvals
+  ([#33](https://github.com/mindhiveoy/pyopenapi_gen/pull/33),
+  [`497f5fa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/497f5fa0ccdec88f90d515adc5c3fddaa4ed40e7))
+
+- Enhance Claude GitHub App configuration for PR approvals
+  ([#34](https://github.com/mindhiveoy/pyopenapi_gen/pull/34),
+  [`08eae74`](https://github.com/mindhiveoy/pyopenapi_gen/commit/08eae74541dbb529cab01ba202ada0333fe2b4f7))
+
 - Remove upper bounds from dependency constraints for better compatibility
   ([`265f9b4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/265f9b46adbe39c9164fd52f189cf75e21d5f5c5))
-
-- Remove upper bounds from typer (<0.14.0) and click (<8.2.0) dependencies - Allows packages to use
-  pyopenapi-gen with newer versions of these dependencies - Fixes dependency conflicts like
-  'pyopenapi-gen (>=0.8.5,<0.9.0) requires typer (>=0.12.0,<0.14.0)' - Bump version to 0.8.6 for
-  compatibility release - Fix mypy type annotation issues in core/utils.py Formatter class
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 
 
 ## v0.8.5 (2025-06-12)
 
 ### Bug Fixes
 
+- Add checkout step to auto-approve workflow
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
+
+- Add checkout step to auto-approve workflow
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
+
 - Add mypy cache corruption resilience to post-processing
   ([`7c9fb58`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7c9fb58f14f3c328d3b85f15d2c6a975bcf3bcee))
 
-Resolves edge cases integration test failures caused by mypy cache corruption errors (KeyError:
-  'setter_type'). Adds automatic retry mechanism with fresh cache when cache corruption is detected.
+- Add staging environment to testpypi workflow and remove PR trigger
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
-- Add retry logic for mypy cache-related errors - Detect specific error patterns like 'KeyError:
-  setter_type' and 'deserialize' - Automatically retry with fresh cache directory on cache
-  corruption - Maintains strict type checking while improving reliability - Fixes
-  test_full_client_generation_with_edge_cases integration test
+- Add staging environment to testpypi workflow and remove PR trigger
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
 - Apply Black formatting to resolve CI formatting differences
   ([`5480eab`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5480eab56c9182399a373f4d4a0ffc8fa09e2894))
 
-Applied Black formatting to fix differences between local and CI environments. This ensures all code
-  follows the exact formatting standard expected by the CI pipeline.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 - Correct response handler logic for error-only operations
   ([`1101f3e`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1101f3ef24f3b0ce4038849d89dbc7ca34dda151))
 
-Fixes issue where operations with only error responses (e.g., 404) were not generating proper match
-  cases. The primary response selection logic would mark an error response as "primary" but then
-  exclude it from processing when it wasn't actually a success response.
+- Correct status event syntax in auto-merge workflow
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
-Changes: - Track whether primary response was actually processed as success - Only exclude primary
-  response from other responses if it was processed - Ensures error responses are properly handled
-  even when no success responses exist - Fixes test_generate_response_handling_error_404 test
+- Correct status event syntax in auto-merge workflow
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
-The issue occurred because _get_primary_response() would fallback to returning the first response
-  (even if it's an error), but the success response processing logic would skip it, leaving it
-  excluded from the error response processing loop.
+- Correct YAML syntax in automation workflows
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
-Aligns with core principle: 2xx responses return data, all others raise exceptions.
+- Correct YAML syntax in automation workflows
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
 - Enable CI workflow for staging branch PRs
   ([`22229ab`](https://github.com/mindhiveoy/pyopenapi_gen/commit/22229ab10fa23edd4dd3f6c13730568306fb5911))
 
-The staging branch protection rules require the 'test' check from CI workflow, but CI was only
-  configured for main/develop branches.
-
-This enables the required status check for staging branch merges.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 - Enable PR checks for staging and main branches
   ([`10d73ba`](https://github.com/mindhiveoy/pyopenapi_gen/commit/10d73ba0d635974eb6dbbb314d2f0a395740cf6b))
 
-This enables the required CI checks (test, security-scan, quality-checks) for PRs targeting staging
-  and main branches, not just develop.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 - Move TestPyPI publish from main to staging branch
   ([`d384b4b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d384b4b76a6a2db57ce9b6c82a1f11e73388e978))
-
-Corrects release pipeline: - staging → TestPyPI (pre-release testing) - main + tags → Production
-  PyPI (official releases)
-
-This prevents double publishing and follows proper release flow.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 
 - Re-enable CI workflow for staging branch PRs
   ([`109003a`](https://github.com/mindhiveoy/pyopenapi_gen/commit/109003a8322520671c0dfb923227047977fc65f2))
@@ -2071,127 +3243,65 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - Re-enable previously skipped cycle detection tests
   ([`ddb3108`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ddb310876906c22a5ce36d68112accf85e89c0af))
 
-- Remove skip decorators from test_composition_cycle_detection and
-  test_complex_cycle_with_multiple_refs - Both tests now pass consistently, indicating the
-  underlying stack management issues have been resolved - Adds coverage for important edge cases:
-  composition cycles (allOf/anyOf/oneOf) and complex multi-path cycles - All 17 cycle detection
-  tests now pass without skips
-
 - Resolve CI import ordering and formatting issues
   ([`8f0a281`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8f0a2819e3dbf61ad8a6e5249952dd227e413ebc))
-
-Fixed import sorting and code formatting inconsistencies between local and CI environments by
-  running ruff format and ruff check --fix across the entire codebase. This ensures all files comply
-  with CI formatting requirements.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 
 - Resolve persistent import ordering issues in test files
   ([`8280a44`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8280a44b4b2d25e2e08d06840ac20718efbe529e))
 
-Fix all I001 import ordering violations in test files that were causing CI failures. Applied proper
-  import order: stdlib imports, blank line, third-party imports (pytest), blank line, local imports.
-
-Affected 60+ test files across all test directories to ensure CI compatibility.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 - Resolve Typer CLI compatibility issue preventing integration tests
   ([`64d28d0`](https://github.com/mindhiveoy/pyopenapi_gen/commit/64d28d087698508cf3b6aa9af0cdc5a1eecefe29))
-
-Fixed TypeError in CLI help system by pinning Typer to stable version <0.14.0 to avoid compatibility
-  issues with make_metavar() method signature changes in newer versions.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 
 - Resolve Typer/Click CLI compatibility issues completely
   ([`11530b3`](https://github.com/mindhiveoy/pyopenapi_gen/commit/11530b3ff510a98aa3181cd5392e93a7a08ebba1))
 
-- Pin Click to <8.2.0 to avoid make_metavar() compatibility issue - Simplify CLI structure by
-  removing subcommand pattern (no more 'gen' subcommand) - Update all CLI tests to use simplified
-  calling pattern - Update comprehensive edge case tests for new CLI structure - Fix HTTP pagination
-  CLI test arguments
+- Resolve workflow validation errors and optimize CI
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
-The CLI now works as: pyopenapi-gen SPEC --project-root PATH --output-package PKG instead of:
-  pyopenapi-gen gen SPEC --project-root PATH --output-package PKG
-
-This resolves the TyperArgument.make_metavar() error that was causing integration tests to fail.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
+- Resolve workflow validation errors and optimize CI
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
 - Update endpoint method generator test for ResponseStrategy parameter
   ([`4e0fd9b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4e0fd9b0cd7483f36a66171913dc2c3fbe0f3946))
 
-The generate_signature and generate_response_handling methods now receive ResponseStrategy as an
-  additional parameter after our refactoring. Updated test assertions to expect this parameter and
-  validate it's a ResponseStrategy instance rather than using exact parameter matching.
-
-Fixes test_generate__basic_flow__calls_helpers_in_order test failure.
-
 - Update integration test workflow for simplified CLI structure
   ([`999ca52`](https://github.com/mindhiveoy/pyopenapi_gen/commit/999ca528c4e62a5549d70062a952c55a60e576b3))
-
-- Remove 'gen' subcommand from integration test workflow - Integration test now uses: pyopenapi-gen
-  SPEC --options instead of pyopenapi-gen gen SPEC --options - Aligns with the simplified CLI
-  structure that removes the subcommand pattern
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 
 - Update poetry.lock after pinning Typer version for CLI compatibility
   ([`c01d285`](https://github.com/mindhiveoy/pyopenapi_gen/commit/c01d2856147d063a6daa384d31097e710b4e558f))
 
-- Regenerated poetry.lock to match pyproject.toml changes - Ensures consistent dependency resolution
-  across environments - Fixes Typer 0.14.0 compatibility issue with Click 8.2.1
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
+- Update poetry.lock after removing Jinja2 dependency
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
 - Update poetry.lock after removing Jinja2 dependency
   ([`994a12a`](https://github.com/mindhiveoy/pyopenapi_gen/commit/994a12a08832c1faa48f66889f85a5f2f28f915f))
 
-- Regenerate poetry.lock to match pyproject.toml changes - Ensures CI builds work correctly after
-  dependency cleanup
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
+- Update poetry.lock after removing Jinja2 dependency
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
 - Update ResponseStrategy tests for simplified no-unwrapping design
   ([`65c906f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/65c906f453fc906c14b2f0c2343a204e31df49cf))
 
-Updates test_response_strategy.py to match the simplified ResponseStrategy that was implemented
-  during the major refactoring. Removes tests for unwrapping functionality that was removed and
-  updates constructor calls to match new IROperation signature requirements.
-
-Changes: - Remove tests for removed fields: needs_unwrapping, unwrap_field, target_schema,
-  wrapper_schema - Remove tests for removed methods: _analyze_unwrapping - Update tests to reflect
-  no-unwrapping behavior (schemas used as-is) - Fix IROperation constructors to include required
-  summary/description - Update import assertions to use assert_any_call for multiple imports - Focus
-  tests on simplified ResponseStrategy with return_type, response_schema, is_streaming, and
-  response_ir fields
-
 ### Chores
+
+- Bump version to 0.8.4 for automation release
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
+
+- Bump version to 0.8.4 for automation release
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
 - Bump version to 0.8.4 for documentation overhaul release
   ([`42779ca`](https://github.com/mindhiveoy/pyopenapi_gen/commit/42779caf28ef2040d36bd34887309d0db0463236))
 
-- Update version in pyproject.toml from 0.8.3 to 0.8.4 - Move changelog entries from Unreleased to
-  0.8.4 section - Document comprehensive documentation improvements and dependency cleanup
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
+- Bump version to 0.8.4 for documentation overhaul release
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
 - Trigger CI workflow for PR status checks
   ([`bd487cf`](https://github.com/mindhiveoy/pyopenapi_gen/commit/bd487cfd01a767994f9f183357633a945e8d789c))
@@ -2199,575 +3309,102 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 ### Documentation
 
 - Professional documentation overhaul and dependency cleanup
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
+
+- Professional documentation overhaul and dependency cleanup
   ([`153ca4b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/153ca4ba254e67fb3172bca8655164e62e64a185))
 
-- Add comprehensive README.md with modern badges and professional structure - Create detailed
-  CONTRIBUTING.md with development guidelines and standards - Establish formal CHANGELOG.md
-  following Keep a Changelog format - Remove unused Jinja2 dependency (project uses visitor pattern,
-  not templates) - Remove feature status promises (Planned, Under Review) - Update project metadata
-  with proper classifiers and URLs - Add documentation index in docs/README.md
+- Professional documentation overhaul and dependency cleanup
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
+- Update branch protection documentation with comprehensive settings
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
 - Update branch protection documentation with comprehensive settings
   ([`45583c8`](https://github.com/mindhiveoy/pyopenapi_gen/commit/45583c85fc829959ea808bae7f20052ff7c0f717))
 
-- Document protection for main, develop, and staging branches - Add deletion and force push
-  protection details - Include CLI commands for branch protection setup - Update quality gates and
-  CI enforcement details
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
+- Update branch protection documentation with comprehensive settings
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
 ### Features
 
 - Achieve 88% test coverage exceeding 85% target
   ([`89e41aa`](https://github.com/mindhiveoy/pyopenapi_gen/commit/89e41aa7173d611a60889b5f12af64685eb4ff72))
 
-- Add comprehensive response resolver tests (86% coverage) * Content type selection logic (JSON
-  preference, JSON variants, fallback) * Streaming response handling (binary, event-stream, with
-  schemas, no content) * Response reference resolution error handling - Add comprehensive schema
-  resolver tests (91% coverage) * anyOf/oneOf/allOf composition handling * String format types
-  (date, datetime, UUID) * Named schema resolution with self-import detection * Reference resolution
-  and error handling * Path calculation edge cases - Fix streaming responses without content to
-  return AsyncIterator[bytes] - Update match case response tests to use ResponseStrategy system -
-  Improve types module coverage from 71% to 88% (57 additional lines covered)
+- Add PR automation with auto-merge and auto-approval
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
 - Add PR automation with auto-merge and auto-approval
   ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
   [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
-* docs: Update branch protection documentation with comprehensive settings
+- Add PR automation with auto-merge and auto-approval workflows
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
-- Document protection for main, develop, and staging branches - Add deletion and force push
-  protection details - Include CLI commands for branch protection setup - Update quality gates and
-  CI enforcement details
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-* docs: Professional documentation overhaul and dependency cleanup
-
-- Add comprehensive README.md with modern badges and professional structure - Create detailed
-  CONTRIBUTING.md with development guidelines and standards - Establish formal CHANGELOG.md
-  following Keep a Changelog format - Remove unused Jinja2 dependency (project uses visitor pattern,
-  not templates) - Remove feature status promises (Planned, Under Review) - Update project metadata
-  with proper classifiers and URLs - Add documentation index in docs/README.md
-
-* fix: Update poetry.lock after removing Jinja2 dependency
-
-- Regenerate poetry.lock to match pyproject.toml changes - Ensures CI builds work correctly after
-  dependency cleanup
-
-* feat: Add PR automation with auto-merge and auto-approval workflows
-
-- Enhanced Claude app permissions for PR management - Added auto-merge workflow for dependabot and
-  release PRs - Added auto-approval workflow for trusted authors - Supports [auto-merge] and
-  [auto-approve] tags in PR titles - Handles integration test failures gracefully for documentation
-  PRs
-
-* fix: Correct YAML syntax in automation workflows
-
-- Fix multiline string formatting in GitHub Actions - Simplify comment bodies to avoid YAML parsing
-  issues - Ensure proper workflow syntax validation
-
-* fix: Correct status event syntax in auto-merge workflow
-
-* chore: Bump version to 0.8.4 for automation release
-
-* fix: Add checkout step to auto-approve workflow
-
-* refactor: Replace auto-merge with Claude GitHub App review system
-
-- Remove auto-merge workflow (not wanted) - Update Claude workflow to trigger on PR events - Replace
-  auto-approve with Claude review trigger - Configure for Claude GitHub App to review and merge PRs
-
-* feat: Enable Claude GitHub App to fix PR issues independently
-
-- Enhanced Claude workflow with full repository access - Added comprehensive fix capabilities for
-  formatting, linting, typing - Updated review trigger to request fixes for fixable issues - Added
-  Claude GitHub App capabilities documentation - Configured for autonomous issue resolution and PR
-  management
-
-* fix: Add staging environment to testpypi workflow and remove PR trigger
-
-- Add environment: staging to access TEST_PYPI_API_TOKEN secret - Remove pull_request trigger to
-  prevent secrets access issues on PRs - Fixes failing build-and-testpypi check by ensuring proper
-  secret access
-
-* feat: Enable Claude auto-review for all PRs targeting develop branch
-
-- Add develop branch target as trigger condition for Claude reviews - Claude will now automatically
-  review and fix issues on all PRs against develop - This ensures code quality checks on the main
-  development branch - Maintains existing triggers for dependabot, devops-mindhive, and
-  [claude-review] tagged PRs
-
-* fix: Resolve workflow validation errors and optimize CI
-
-- Remove invalid 'metadata' permission from claude.yml workflow - Consolidate duplicate test runs in
-  CI workflow - generate both XML and HTML coverage in single run - Improves CI efficiency by
-  eliminating redundant test execution
-
----------
-
-Co-authored-by: mindhivefi <ville@mindhive.fi>
-
-Co-authored-by: Claude <noreply@anthropic.com>
+- Add PR automation with auto-merge and auto-approval workflows
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
 - Complete systematic migration of response handler generator tests to ResponseStrategy pattern
   ([`1c7d4f5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1c7d4f5ed8d6ff11c37ed96a25bc5d058ad06033))
 
-✅ MAJOR MILESTONE: All response handler generator tests now use ResponseStrategy pattern
+- Enable Claude auto-review for all PRs targeting develop branch
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
-- Updated all 18 response handler generator tests to use ResponseStrategy instead of
-  get_return_type_unified - Fixed fixture usage patterns: converted all self.* references to proper
-  pytest fixture parameters - Updated assertion styles: converted unittest assertions
-  (self.assertIn, self.assertTrue) to pytest assertions - Fixed import expectations to match new
-  ResponseStrategy behavior - Removed problematic add_typing_imports_for_type assertions that no
-  longer apply - All 18/18 tests now passing with new ResponseStrategy contract
+- Enable Claude auto-review for all PRs targeting develop branch
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
-🔄 Systematic changes applied: - Replaced get_return_type_unified patches with ResponseStrategy
-  object creation - Updated method signatures to include proper fixture parameters (generator,
-  code_writer_mock, render_context_mock) - Converted self.render_context_mock → render_context_mock
-  - Converted self.code_writer_mock → code_writer_mock - Converted self.generator → generator -
-  Converted self.assertIn() → assert ... in ... - Converted self.assertTrue() → assert ... -
-  Converted self.assertNotIn() → assert ... not in ...
+- Enable Claude GitHub App to fix PR issues independently
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
 
-📈 Coverage: 100% of response handler generator tests now follow modern patterns 🎯 Next: Complete
-  systematic audit of remaining endpoint generator test patterns
+- Enable Claude GitHub App to fix PR issues independently
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
 - Implement automatic JSON-to-dataclass conversion with field mapping
   ([`1c42a47`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1c42a4754fe9c07c1be19b82da6e808a62cfeae9))
 
-- Add dataclass-wizard dependency for automatic JSON serialization/deserialization - Generate
-  dataclasses with JSONWizard inheritance when field mapping is needed - Implement field name
-  mapping from camelCase to snake_case automatically - Update response handlers to use .from_dict()
-  instead of unsafe cast() operations - Add comprehensive test coverage for all new functionality -
-  Move coverage reports to coverage_reports/ subfolder and update .gitignore
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 - Production release v0.8.5 - JSON-to-dataclass conversion with ResponseStrategy migration
   ([`d5e9b4a`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d5e9b4a33f6cd277fca6595c2df479bc1cce5bec))
-
-## Major Features - JSON-to-dataclass automatic conversion with BaseSchema integration - Unified
-  ResponseStrategy architecture replacing legacy response handling - Python 3.12+ exclusive support
-  for modern development
-
-## Technical Improvements - Complete removal of deprecated get_return_type_unified function -
-  Enhanced test coverage with pytest migration (29+ test files) - CLI compatibility fixes for
-  Typer/Click integration - DataclassWizard integration for robust JSON handling
-
-## Dependencies - Added: dataclass-wizard>=0.22.0, click>=8.0.0,<8.2.0 - Updated:
-  typer>=0.12.0,<0.14.0, Python 3.12+ only
-
-Ready for production release with comprehensive quality improvements.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-- Production release v0.8.5 - ResponseStrategy migration and Python 3.12+ only
-  ([`e92ab02`](https://github.com/mindhiveoy/pyopenapi_gen/commit/e92ab021766b54b3419a817168802329ab575a04))
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 
 ### Refactoring
 
 - Complete ResponseStrategy migration and remove deprecated function
   ([`3671d49`](https://github.com/mindhiveoy/pyopenapi_gen/commit/3671d49e1123275fedc41c178811abecc33e21c6))
 
-- Remove get_return_type_unified function completely from codebase - Migrate all endpoint generators
-  to use ResponseStrategy pattern - Update 29 tests across 4 major test files to use new pattern -
-  Convert unittest-style tests to pytest fixture patterns - Fix import ordering and formatting
-  issues - Add missing type stubs for PyYAML and bandit dependencies - Clean up debug scripts and
-  old references
-
-All 1265 tests passing with full quality checks (format, lint, typecheck, security).
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
 - Remove duplicate FieldMapper class and use existing NameSanitizer
   ([`d42f681`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d42f6818b451dab3edbd55a6eaf78cf9aab76306))
-
-- Remove redundant FieldMapper class that duplicated existing camelCase conversion - Use existing
-  NameSanitizer.sanitize_method_name() for field name conversion - Add helper methods to
-  DataclassGenerator for field mapping logic - Remove duplicate test files for FieldMapper
-  functionality - Maintain all existing JSONWizard functionality using existing utilities
 
 - Remove get_return_type_unified function completely from codebase
   ([`eccde2d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/eccde2de2a5a20dca85b4febd376ab0d7640e741))
 
-- Deleted function from src/pyopenapi_gen/helpers/endpoint_utils.py - Removed test class
-  TestGetReturnTypeUnified from test_endpoint_utils_extended.py - Updated signature generator tests
-  to use ResponseStrategy pattern - Updated docstring generator tests to use ResponseStrategy
-  pattern - Updated import analyzer tests to use ResponseStrategy pattern (8/8 tests) - All source
-  code now exclusively uses ResponseStrategy pattern
-
-🚧 Next: Need to update response handler generator tests (18 tests with patches to fix)
-
 - Remove unwrapping logic and fix array type alias handling
   ([`97bedc1`](https://github.com/mindhiveoy/pyopenapi_gen/commit/97bedc14355bbb8c970ec39e19290eb09ecc8ea4))
 
-- Remove entire unwrapping system from ResponseStrategy and response resolver - Use OpenAPI schemas
-  exactly as defined (no automatic data property unwrapping) - Fix array type alias detection to
-  prevent incorrect .from_dict() calls on list types - Add type alias detection methods to
-  distinguish between: - Array type aliases (AgentHistoryListResponse = list[AgentHistory]) → use
-  cast() - Primitive type aliases (StringAlias = str) → use cast() - Dataclass models (class
-  User(BaseSchema): ...) → use .from_dict() - Update all tests to expect no-unwrapping behavior -
-  Remove obsolete test functions and duplicate cycle detection tests - Require Python 3.12+ and
-  update CI/documentation accordingly
+- Replace auto-merge with Claude GitHub App review system
+  ([#13](https://github.com/mindhiveoy/pyopenapi_gen/pull/13),
+  [`fdf3786`](https://github.com/mindhiveoy/pyopenapi_gen/commit/fdf37868ddcedab065edf959d6f4ababa534499c))
+
+- Replace auto-merge with Claude GitHub App review system
+  ([#12](https://github.com/mindhiveoy/pyopenapi_gen/pull/12),
+  [`4c9346d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/4c9346d0c41735d60a4fd27ff01f68b0dbacdb51))
 
 - Systematic update to ResponseStrategy pattern
   ([`465c670`](https://github.com/mindhiveoy/pyopenapi_gen/commit/465c670d4932ad520888b5a558c1ad4eaf47aaed))
 
-- Update import analyzer to accept ResponseStrategy parameter - Update docstring generator to use
-  ResponseStrategy.return_type - Remove dead code from endpoint visitor - Update 3/8 import analyzer
-  tests to use ResponseStrategy - Maintain systematic consistency across codebase
-
-Progress: Source code fully updated, tests being systematically migrated
-
 - Update response handler generator tests to use ResponseStrategy pattern (7/18 completed)
   ([`eafa2c3`](https://github.com/mindhiveoy/pyopenapi_gen/commit/eafa2c3e83d984232d8f48bb23d1a4caec501b2b))
-
-- Removed all 7 get_return_type_unified patches from response handler tests - Updated
-  test_generate_response_handling_default_as_primary_success_heuristic to use ResponseStrategy -
-  Updated test_generate_response_handling_multiple_2xx_distinct_types to use ResponseStrategy -
-  Updated test_generate_response_handling_streaming_bytes to use ResponseStrategy - Updated
-  test_generate_response_handling_streaming_sse to use ResponseStrategy - Updated
-  test_generate_response_handling_union_return_type to use ResponseStrategy - Updated
-  test_generate_response_handling_union_return_type_with_unwrap_first to use ResponseStrategy -
-  Updated test_generate_response_handling_simple_type_with_unwrap to use ResponseStrategy
-
-- Fixed fixture usage patterns (self. -> fixture parameters) - Updated assertion patterns
-  (self.assertIn -> assert, self.assertTrue -> assert) - Corrected import expectations to match new
-  ResponseStrategy behavior
-
-🚧 Next: Fix remaining response handler generator tests with self. patterns and complete the
-  systematic cleanup
 
 
 ## v0.8.3 (2025-06-11)
 
-### Bug Fixes
-
-- Improve file writing robustness in ModelsEmitter for CI stability
-  ([`84c49f8`](https://github.com/mindhiveoy/pyopenapi_gen/commit/84c49f8ecdac2f8849edbba6971998d59dbaa743))
-
-- Add atomic file writing using temporary files to prevent race conditions - Add defensive directory
-  creation validation - Add file existence verification after writing - This should fix the 4
-  failing tests in CI that pass locally
-
-The issue was likely related to parallel test execution in CI environments where directory creation
-  and file writing could have race conditions.
-
-- Make Codecov upload non-blocking
-  ([`2eecbf5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/2eecbf52f8b02bb308079125633a36f342991bfb))
-
-Set fail_ci_if_error: false to prevent CI failure when Codecov token is missing.
-
-- Optimize parallel testing configuration for CI stability
-  ([`f9970bc`](https://github.com/mindhiveoy/pyopenapi_gen/commit/f9970bc6921e4b222918eba723d6469c97256952))
-
-- Reduce parallel workers from 4 to 2 for better stability in CI environment - Reduce timeout from
-  300s to 120s per test for faster failure detection - Update both GitHub Actions workflows and
-  local Makefile consistently - Maintain test coverage requirement at 85%
-
-This resolves CI test failures that were likely caused by: - Resource contention with too many
-  parallel workers - Timeouts not being properly handled in CI environment - File system conflicts
-  during parallel test execution
-
-Local testing confirms 88% coverage with stable execution.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-- Resolve critical CI failures with dependency and Poetry configuration
-  ([`5825f2b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/5825f2b16393dd238838744fe638c08b3e568478))
-
-- Remove duplicate dependencies (black, mypy, ruff) from main dependencies - Add missing PyYAML
-  dependency (critical - CLI was failing immediately) - Fix Poetry installation command: use
-  --extras dev for PEP 621 dependencies - Consolidate all dev tools into
-  [project.optional-dependencies] section only - Remove conflicting
-  [tool.poetry.group.dev.dependencies] section - Broaden dependency version constraints for Python
-  3.10-3.12 compatibility - Fix typer version constraint to avoid TypeError in CLI help - Make
-  safety check more resilient with --json flag and non-blocking behavior - Update poetry.lock with
-  new dependency configuration
-
-These changes address the root causes of CI pipeline failures: - "Group(s) not found: dev (via
-  --with)" error fixed - Dependency conflicts resolved - Missing runtime dependencies added
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-- Resolve critical dependency conflicts in pyproject.toml
-  ([`8b61c08`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8b61c0896fab6648523e2919a9969a9429c1c53f))
-
-- Remove dev tools (black, mypy, ruff, types-pyyaml) from main dependencies - Consolidate all dev
-  dependencies into PEP 621 optional-dependencies section - Remove conflicting Poetry-specific
-  [tool.poetry.group.dev.dependencies] section - Add missing CI dependencies (safety, bandit,
-  pytest-xdist, pytest-asyncio, types-toml, httpx) - Ensure proper library vs application dependency
-  separation
-
-This resolves CI failures caused by: 1. Duplicate dependencies with conflicting version constraints
-  2. Configuration format mixing between PEP 621 and Poetry sections 3. Missing packages required by
-  CI workflows
-
-Co-authored-by: mindhivefi <mindhivefi@users.noreply.github.com>
-
-- Resolve remaining mypy issues with match-case return type checking
-  ([`aa6a536`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aa6a536f6db142053a0e3ae7d0cf7bedebcdc1bf))
-
-## Issue Fixed - Added explicit assertion at end of match-case response handlers to satisfy mypy's
-  strict return type checking - All originally failing tests now pass: 5/5 ✅
-
-## Technical Details - Added `assert False, 'Unexpected code path'` with `# pragma: no cover` to
-  match-case generators - This ensures mypy recognizes all code paths are covered while maintaining
-  clean generated code - The assertion should never execute in practice due to comprehensive match
-  cases
-
-## Test Results ✅ **ALL ORIGINALLY FAILING TESTS NOW PASS**: -
-  test_endpoints_emitter__json_request_body__generates_body_parameter_and_json_assignment -
-  test_endpoints_emitter__multipart_form_data__generates_files_parameter_and_assignment -
-  test_generate_client__shared_core_client_in_subdir__correct_paths_and_imports -
-  test_generate_client__core_in_custom_project_subdir__correct_imports -
-  test_business_swagger_generation
-
-✅ **No regressions**: All endpoint generator tests (47/47) and dataclass serialization tests (14/14)
-  pass
-
-The match-case refactoring and dataclass serialization features are now fully working and tested.
-
-- Resolve security and linting issues for CI/CD pipeline
-  ([`6e0ad91`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6e0ad91b10c86d938986ac01e979ec56b0adc17a))
-
-## Summary - Fix Bandit security scanner warnings - Fix specific code quality issues identified by
-  Ruff
-
-## Changes - **Security**: Configure .bandit to skip acceptable assert warnings - **Security**:
-  Replace hardcoded /tmp path with tempfile.gettempdir() - **Code Quality**: Fix bare except clause
-  with specific exceptions - **Import Management**: Clean up unused imports automatically
-
-## Quality Improvements - More secure temp file handling - Specific exception handling instead of
-  bare except - Proper Bandit configuration for code generation tool
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-- Run problematic models emitter tests in serial to prevent CI failures
-  ([`d04492c`](https://github.com/mindhiveoy/pyopenapi_gen/commit/d04492c0802a6079b5491e7302af3ec3f5e36cb8))
-
-- Run the 4 failing models emitter tests in serial mode before parallel execution - Add enhanced
-  error logging and debugging to models emitter file writing - Update CI workflows and Makefile to
-  handle these tests separately - This addresses CI-specific race conditions in parallel test
-  execution
-
-The tests pass locally but fail in CI due to file system race conditions when using pytest-xdist
-  parallel execution. Running them serially first should resolve the issue while maintaining overall
-  test performance.
-
-- Skip problematic models emitter tests in CI environment
-  ([`eb608ff`](https://github.com/mindhiveoy/pyopenapi_gen/commit/eb608ff150e36429368fa39619a8b9834ed05f32))
-
-- Add @pytest.mark.skipif decorators to 4 failing tests that only fail in CI - The tests work
-  perfectly locally but fail in CI due to environment differences - Skip them when CI=true
-  environment variable is set - Restore normal CI workflow without debug mode - Update Makefile and
-  workflows to remove workarounds
-
-These tests verify file generation functionality that works in development but has CI-specific
-  issues. This ensures the CI pipeline is stable while preserving the test coverage for local
-  development.
-
-- Update remaining GitHub Actions workflows to use --extras dev
-  ([`86c1bc4`](https://github.com/mindhiveoy/pyopenapi_gen/commit/86c1bc493d9986d04c99e7ea68a1af10b500d165))
-
-- Fix ci.yml, pypi-publish.yml, and testpypi-publish.yml - Change from --with dev to --extras dev
-  for PEP 621 compatibility - Ensures all workflows use consistent Poetry installation commands
-
-This resolves the remaining CI failures with 'Group(s) not found: dev (via --with)' error.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-- Update test assertions to match actual comment messages
-  ([`597791b`](https://github.com/mindhiveoy/pyopenapi_gen/commit/597791bb6c01c742e52c454c14a723afe20908d9))
-
-- Fix comment message assertions in URL args generator tests - Align test expectations with actual
-  implementation output
-
-- Use PyPI-compatible dev versioning for staging releases
-  ([`9c67877`](https://github.com/mindhiveoy/pyopenapi_gen/commit/9c67877d278e61edba008852a18083545acd9f3f))
-
-- Replace local version identifiers with dev version numbers - Use build number instead of commit
-  hash for compatibility - Update release description with installation instructions - This fixes
-  TestPyPI upload rejection of local versions
-
-### Chores
-
-- Update poetry.lock after dependency changes
-  ([`7312213`](https://github.com/mindhiveoy/pyopenapi_gen/commit/73122130b69465e7fdc86fa668d958991ff302f3))
-
-- Regenerate poetry.lock to match updated pyproject.toml dependencies - Fixes CI failure:
-  'pyproject.toml changed significantly since poetry.lock was last generated'
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-### Code Style
-
-- Apply Black formatting to models_emitter.py
-  ([`ef7096d`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ef7096d050fad660ca3128f2c8c52cb3c03fc593))
-
-Fix formatting issues in the atomic file writing implementation.
-
-- Apply Black formatting to source files
-  ([`7561cd3`](https://github.com/mindhiveoy/pyopenapi_gen/commit/7561cd351891f75f252920b7e0aaf8a1a5bcf9f2))
-
-Apply consistent code formatting using Black formatter to improve code readability and maintain
-  consistent style across the codebase.
-
-Changes include: - Line length adjustments to 120 characters - Consistent string quoting - Proper
-  spacing and indentation - Import statement formatting
-
-No functional changes, only formatting improvements.
-
-- Apply Black formatting to test_models_emitter.py
-  ([`8992c0f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/8992c0fa56e89448a42cbc4a321d296e557ddf57))
-
-Fix code formatting issues in test file.
-
-- Fix Black formatting in models_emitter.py
-  ([`9cfece9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/9cfece98c5041671fa60782224a09ebe6bef548e))
-
-Add blank line after import statement as required by Black.
-
-- Fix code formatting issues
-  ([`77f14b9`](https://github.com/mindhiveoy/pyopenapi_gen/commit/77f14b92f4f2ba95ff47bf62b644e0d4d3d51e16))
-
-- Apply black formatting to all test files - Fix spacing and line break issues identified by CI -
-  Ensure consistent code style across project
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-- Fix import organization and remove unused imports
-  ([`1e426f5`](https://github.com/mindhiveoy/pyopenapi_gen/commit/1e426f5241e159385e2812100d924af9c3e96a33))
-
-- Organize imports according to PEP 8 and ruff standards - Remove unused imports (pytest,
-  typing.Any, MagicMock, os) - Fix import ordering in test files - Ensure consistent import style
-  across codebase
-
-All quality checks now passing: - Black formatting ✅ - Ruff linting ✅ - MyPy type checking ✅ -
-  Project builds successfully ✅
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-- Fix minor formatting issue in test_init.py
-  ([`46e18fe`](https://github.com/mindhiveoy/pyopenapi_gen/commit/46e18fef996c99a0182728e0199f165b03844eb0))
-
-- Remove extra blank line to match Black formatting requirements - Ensure all files pass Black
-  formatting checks
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-### Features
-
-- Add automatic dataclass to dictionary serialization for generated clients
-  ([`ae0654f`](https://github.com/mindhiveoy/pyopenapi_gen/commit/ae0654fd91c0fe788b4da7cb077af0159bd2546b))
-
-Implement seamless dataclass support for request bodies, dramatically improving developer experience
-  by eliminating manual dictionary conversion.
-
-## Key Features
-
-- **DataclassSerializer utility**: Automatic conversion of dataclass instances to dictionaries -
-  Recursive handling of nested dataclasses, lists, and dictionaries - Smart datetime serialization
-  (ISO format) - None value exclusion for clean JSON output - Circular reference detection and
-  graceful handling - Fallback support for unknown types
-
-- **Code generation integration**: Automatic serialization in generated endpoint methods - JSON
-  bodies: `json_body = DataclassSerializer.serialize(body)` - Form data: `form_data_body =
-  DataclassSerializer.serialize(form_data)` - Multipart data: `files_data =
-  DataclassSerializer.serialize(files)` - Proper import management in generated clients
-
-## Developer Experience Improvement
-
-**Before**: ```python # Manual conversion required client.create_user(dataclasses.asdict(user_data))
-  ```
-
-**After**: ```python # Direct dataclass usage - just works\! ✨ client.create_user(user_data) ```
-
-## Implementation Details
-
-- Added `DataclassSerializer` class to `core/utils.py` - Integrated automatic serialization in
-  `url_args_generator.py` - Comprehensive test coverage (30 tests) across multiple test suites -
-  Maintains backward compatibility with existing dictionary inputs - Type-safe implementation with
-  proper error handling - Zero additional runtime dependencies
-
-## Test Coverage
-
-- Core serialization functionality tests - Code generation integration tests - End-to-end generated
-  client method tests - Developer experience demonstration tests
-
-Generated clients now provide a seamless, intuitive API for dataclass inputs while maintaining full
-  compatibility with traditional dictionary-based usage.
-
-- Add comprehensive GitHub Actions CI/CD pipeline
-  ([`aa9e983`](https://github.com/mindhiveoy/pyopenapi_gen/commit/aa9e9830cdec1d98cf391cc2cb8f7f7921316a41))
-
-## Summary - Add automated PR checks for develop branch protection - Add comprehensive testing and
-  quality gates - Add security scanning and dependency management
-
-## Changes - **CI/CD Pipeline**: Complete GitHub Actions workflow for PR validation - **Quality
-  Gates**: Black formatting, Ruff linting, MyPy type checking enforced - **Testing**: Multi-Python
-  version testing (3.10, 3.11, 3.12) with 90% coverage requirement - **Security**: Safety and Bandit
-  security scanning - **Integration**: CLI functionality and client generation verification -
-  **Branch Protection**: Documentation for configuring develop branch protection - **Automation**:
-  Dependabot for dependency updates - **Project Management**: Issue templates, CODEOWNERS, and
-  contribution guidelines
-
-## Pipeline Features - **Pull Request Checks**: Enforces all quality gates before merge to develop -
-  **Main Branch Validation**: Comprehensive testing on main branch pushes - **Performance Testing**:
-  Large specification processing validation - **Multi-Environment**: Tests across Python 3.10-3.12
-  on Ubuntu - **Artifact Management**: Coverage reports and build artifacts - **Security First**:
-  Automated vulnerability scanning
-
-## Quality Gates Enforced - ✅ Code formatting (Black) - ✅ Linting (Ruff) - ✅ Type checking (MyPy
-  strict mode) - ✅ Unit & integration tests (90% coverage minimum) - ✅ CLI functionality
-  verification - ✅ Generated client structure validation - ✅ Security vulnerability scanning - ✅
-  Dependency safety checks
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
-
-- Add staging and production release pipelines
-  ([`6da42ce`](https://github.com/mindhiveoy/pyopenapi_gen/commit/6da42ce4bea566c94796a887a9891dd4dd3664ac))
-
-- Add staging-publish.yml for TestPyPI releases with dev versions - Add production-release.yml for
-  PyPI releases with tags and changelog - Add promote-to-staging.yml for branch promotion workflow -
-  Make integration tests non-blocking in PR checks
-
-These workflows enable: - Staging: Auto-deploy to TestPyPI on staging branch push - Production:
-  Deploy to PyPI on tag push with changelog generation - Promotion: Easy staging branch creation
-  from develop
+- Initial Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,34 +155,45 @@ changelog_format = "## [$version] - $date\\n\\n$changes"
 commit_parser = "^(?P<change_type>feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\((?P<scope>[^)]+)\\))?!?:\\s(?P<message>.+)$"
 bump_message = "bump: version $current_version → $new_version"
 
+# Config schema is python-semantic-release v8+. Do NOT reintroduce the v7-era keys
+# (branch, hvcs, tag_commit, upload_to_pypi, upload_to_repository, changelog_file,
+# changelog_format, allowed_bots) — v10 silently IGNORES unknown keys, which is how
+# changelog generation stayed broken from v0.23.1 through v5.1.8 without any error.
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version", "pyproject.toml:tool.commitizen.version"]
 version_variables = [
     "src/pyopenapi_gen/__init__.py:__version__"
 ]
-branch = "main"
-upload_to_pypi = false
-upload_to_repository = false
 commit_message = "chore(release): {version}"
-tag_commit = true
-changelog_file = "CHANGELOG.md"
-changelog_format = "# Changelog\\n\\n{changelog}"
-hvcs = "github"
 commit_parser = "conventional"
+tag_format = "v{version}"
 major_on_zero = false
-# Allow bot actors (dependabot, renovate, etc.) to trigger releases
-allowed_bots = ["dependabot", "renovate"]
 
-# Exclude verbose dependency update commits from release notes
-# These commits still trigger patch releases, but don't clutter changelog
-# This prevents GitHub API 422 errors from oversized release note bodies
+# Releases are cut from main only. Replaces the v7-era `branch = "main"`.
+[tool.semantic_release.branches.main]
+match = "main"
+
+[tool.semantic_release.remote]
+type = "github"
+
+# mode = "update" inserts each new release above `insertion_flag`. If that marker is
+# missing from CHANGELOG.md, python-semantic-release writes NOTHING and exits 0 — the
+# exact silent failure that froze this changelog for five major versions. Keep the
+# marker in CHANGELOG.md.
 [tool.semantic_release.changelog]
+mode = "update"
+insertion_flag = "<!-- version list -->"
+# `^deps:` / `^deps-dev:` were dropped: dependabot now emits conventional `fix(deps)`
+# commits (see .github/dependabot.yml), and those are the changes a release documents,
+# so they belong in the notes rather than being filtered out of them.
 exclude_commit_patterns = [
     "^chore\\(deps\\): merge dependabot",
     "^chore\\(deps-dev\\): merge dependabot",
-    "^deps:",
-    "^deps-dev:",
 ]
+
+[tool.semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
+output_format = "md"
 
 [tool.coverage.run]
 # Store coverage data files under coverage_reports/ instead of project root

--- a/scripts/sync_version_to_init.py
+++ b/scripts/sync_version_to_init.py
@@ -48,8 +48,9 @@ def extract_init_version(init_path: Path) -> str | None:
         print(f"❌ File not found: {init_path}")
         return None
 
-    # Extract __version__ (line 53: __version__: str = "0.15.0")
-    version_match = re.search(r'^__version__\s*:\s*str\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    # Extract __version__ (e.g. __version__ = "0.15.0"). The optional `: str` keeps this
+    # tolerant of both forms; semantic-release can only rewrite the unannotated one.
+    version_match = re.search(r'^__version__\s*(?::\s*str\s*)?=\s*"([^"]+)"', content, re.MULTILINE)
     return version_match.group(1) if version_match else None
 
 
@@ -71,7 +72,7 @@ def update_init_version(init_path: Path, new_version: str) -> bool:
 
     # Replace version with new version
     new_content = re.sub(
-        r'^(__version__\s*:\s*str\s*=\s*)"[^"]+"',
+        r'^(__version__\s*(?::\s*str\s*)?=\s*)"[^"]+"',
         rf'\1"{new_version}"',
         content,
         flags=re.MULTILINE,

--- a/scripts/validate_version_sync.py
+++ b/scripts/validate_version_sync.py
@@ -63,8 +63,9 @@ def extract_init_version(init_path: Path) -> str | None:
         print(f"❌ File not found: {init_path}")
         return None
 
-    # Extract __version__ (line 46: __version__: str = "0.14.3")
-    version_match = re.search(r'^__version__\s*:\s*str\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    # Extract __version__ (e.g. __version__ = "0.14.3"). The optional `: str` keeps this
+    # tolerant of both forms; semantic-release can only rewrite the unannotated one.
+    version_match = re.search(r'^__version__\s*(?::\s*str\s*)?=\s*"([^"]+)"', content, re.MULTILINE)
     return version_match.group(1) if version_match else None
 
 

--- a/src/pyopenapi_gen/__init__.py
+++ b/src/pyopenapi_gen/__init__.py
@@ -54,7 +54,10 @@ __all__ = [
 ]
 
 # Semantic version of the generator core – automatically managed by semantic-release.
-__version__: str = "5.1.8"
+# Keep this as a bare assignment: semantic-release's `version_variables` pattern only
+# accepts a single separator after the name, so a `: str` annotation makes it silently
+# fail to rewrite this line (mypy still infers str here).
+__version__ = "5.1.8"
 
 # ---------------------------------------------------------------------------
 # Lazy-loading and autocompletion support (This part remains)


### PR DESCRIPTION
## Summary

Makes the release pipeline run unattended. Four defects were compounding, each failing silently.

> **Stacked on #369** (back-merge of v5.1.8). Merge #369 first; this PR then shows only its own commits.

> ⚠️ **One-time setup required before this fully works** — see *Action required* at the bottom.

## 1. CHANGELOG.md was never generated (stale since v0.23.1)

Two independent causes.

**v7-era config keys that v10 silently ignores.** `[tool.semantic_release]` carried eight keys that python-semantic-release 10.6.1 does not recognise — `branch`, `hvcs`, `tag_commit`, `upload_to_pypi`, `upload_to_repository`, `changelog_file`, `changelog_format`, `allowed_bots`. Unknown keys raise no error, so nothing ever surfaced. Verified by introspecting the installed `RawConfig` model: the migrated config now has **zero** ignored keys.

**The real blocker — a missing marker.** `changelog.mode` defaults to `update`, which inserts each release above `insertion_flag` (default `<!-- version list -->`). That marker was **absent** from CHANGELOG.md, so PSR had nowhere to insert, wrote nothing, and **exited 0**.

Fixes: config migrated to the v8+ schema (`branches.main`, `remote.type`, `changelog.mode`/`insertion_flag`, `changelog.default_templates`), and the marker is now present. CHANGELOG.md is **backfilled to all 72 released versions** via a one-time `mode = "init"` regeneration — including v5.1.8, which shipped undocumented.

## 2. The back-merge into develop/staging could never work

A PR opened with the default `GITHUB_TOKEN` does not emit a `pull_request` event (GitHub's recursion guard), so develop's required checks never run and the PR cannot merge past `enforce_admins`. The step was right to refuse, but no elevated credential existed — so **every** release left develop behind.

A **GitHub App installation token** is now minted per run via `actions/create-github-app-token` and used for both the branch push and the PR creation. App tokens are re-minted each run and expire in ~1h, so unlike a PAT there is no expiry date to silently break the pipeline months later. `SEMANTIC_RELEASE_TOKEN` still works as a fallback.

The branch push previously reused `actions/checkout`'s persisted credentials — a branch pushed under that identity is a dead end for auto-merge — so the remote URL is now re-pointed at the elevated token.

## 3. Dependency merges never released

Dependabot used `deps:` / `deps-dev:` prefixes. **Those are not conventional commit types**, so the parser ignored them and computed no bump. This is the actual reason v5.1.8 needed the hand-written trigger commit in #368.

Prefixes are now `fix`, producing `fix(deps):` / `fix(deps-dev):` → patch bump, no manual commit ever again.

I did **not** implement this by adding `chore` to `commit_parser_options.patch_tags`, as originally sketched: that would make `chore(release):` commits themselves release-worthy (a self-trigger loop guarded only by a commit-message string match) and would cut empty releases on unrelated `chore:` commits. The Dependabot prefix achieves the same outcome with neither risk. To stop dev-only bumps from releasing, change `prefix-development` to `chore` — one line, documented inline.

## 4. `version_variables` silently failed on `__init__.py`

PSR's generated pattern accepts only a single separator after the variable name, so `__version__: str = "..."` never matched and release commits left `__init__.py` behind. The workflow papered over it with a separate sync step that pushed an extra `chore(release)` commit every release — visible as changelog noise.

Dropping the annotation (mypy still infers `str`; strict passes on 124 files) lets PSR rewrite all three version locations in the release commit itself. The sync step remains as a no-op safety net. `validate_version_sync.py` and `sync_version_to_init.py` hardcoded the annotated form and would have reported `NOT FOUND`; both now accept either.

## Verification

Simulated a full future release in an isolated clone with the real remote, using only a `fix(deps): bump typer...` commit:

```
5.1.9
chore(release): 5.1.9
 CHANGELOG.md                  | 19 +++++++++++++++++++
 pyproject.toml                |  4 ++--
 src/pyopenapi_gen/__init__.py |  2 +-
```

- A dependency commit **alone** drove the release — confirming defect 3 is fixed
- CHANGELOG.md is **in the release commit**, with `## v5.1.9` inserted above v5.1.8
- All three version locations reached 5.1.9 in one atomic commit
- The insertion flag survives, so the fix is **idempotent** for subsequent releases

Also: `make quality` clean, **1661 tests pass at 89.47%**, all three workflow/dependabot YAML files parse, and the release gate correctly classifies `fix(deps)`/`fix(deps-dev)` as release-worthy while `ci:` and `chore(release):` are not.

## ⚠️ Action required — the back-merge stays broken until this is done

1. Create a **GitHub App** in the `mindhiveoy` org with repository permissions **Contents: read & write** and **Pull requests: read & write**
2. Install it on `pyopenapi_gen`
3. Add repository secrets **`RELEASE_APP_ID`** and **`RELEASE_APP_PRIVATE_KEY`**

Until those exist the release itself still works (tag + PyPI), and the back-merge fails with an explicit message naming exactly what to configure — rather than silently leaving develop behind.

## Not addressed here

- **`staging` is ~26 files behind `main`** (source and tests, not just release commits) and needs its own reconciliation.
- **`dataclass-wizard`** is a declared production dependency with zero imports anywhere; serialization moved to `cattrs`. Likely removable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/mindhiveoy/codesmith/pyopenapi_gen/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787851257&installation_model_id=424599&pr_number=370&repository=mindhiveoy%2Fpyopenapi_gen&return_to=https%3A%2F%2Fgithub.com%2Fmindhiveoy%2Fpyopenapi_gen%2Fpull%2F370&signature=c12dd8020ec483490876686caae341d8d239f9febf7c9d116d1c979ad735c53a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->